### PR TITLE
Fix dialyzer issues and use :ok tuples when :error tuples are possible

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,5 @@
 # Used by "mix format"
 [
-  inputs: ["mix.exs", "{benchmarks,config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["mix.exs", "{benchmarks,config,lib,test}/**/*.{ex,exs}"],
+  line_length: 120
 ]

--- a/lib/adapter.ex
+++ b/lib/adapter.ex
@@ -1,11 +1,11 @@
 defmodule Spandex.Adapter do
   @moduledoc """
-  The callbacks required to implement an adapter.
+  The callbacks required to implement the Spandex.Adapter behaviour.
   """
 
   @callback distributed_context(Plug.Conn.t(), Keyword.t()) :: {:ok, term} | {:error, term}
-  @callback trace_id() :: term
-  @callback span_id() :: term
-  @callback now() :: term
-  @callback default_sender() :: module
+  @callback trace_id() :: Spandex.id()
+  @callback span_id() :: Spandex.id()
+  @callback now() :: Spandex.timestamp()
+  @callback default_sender() :: module()
 end

--- a/lib/plug/add_context.ex
+++ b/lib/plug/add_context.ex
@@ -24,15 +24,13 @@ defmodule Spandex.Plug.AddContext do
                required: [:tracer],
                describe: [
                  tracer: "The tracing module to be used to start the trace.",
-                 tracer_opts:
-                   "Any opts to be passed to the tracer when starting or continuing the trace.",
+                 tracer_opts: "Any opts to be passed to the tracer when starting or continuing the trace.",
                  allowed_route_replacements:
                    "A list of route parts that may be replaced with their actual value. " <>
                      "If not set or set to nil, then all will be allowed, unless they are disallowed.",
                  disallowed_route_replacements:
                    "A list of route parts that may *not* be replaced with their actual value.",
-                 query_params:
-                   "A list of query params who's value will be included in the resource name."
+                 query_params: "A list of query params who's value will be included in the resource name."
                ]
              )
 

--- a/lib/plug/end_trace.ex
+++ b/lib/plug/end_trace.ex
@@ -17,8 +17,7 @@ defmodule Spandex.Plug.EndTrace do
                required: [:tracer],
                describe: [
                  tracer: "The tracing module to be used to start the trace.",
-                 tracer_opts:
-                   "Any opts to be passed to the tracer when starting or continuing the trace."
+                 tracer_opts: "Any opts to be passed to the tracer when starting or continuing the trace."
                ]
              )
 

--- a/lib/plug/start_trace.ex
+++ b/lib/plug/start_trace.ex
@@ -25,11 +25,9 @@ defmodule Spandex.Plug.StartTrace do
                describe: [
                  ignored_methods:
                    "A list of strings representing methods to ignore. A good example would be `[\"OPTIONS\"]`",
-                 ignored_routes:
-                   "A list of strings or regexes. If it is a string, it must match exactly.",
+                 ignored_routes: "A list of strings or regexes. If it is a string, it must match exactly.",
                  tracer: "The tracing module to be used to start the trace.",
-                 tracer_opts:
-                   "Any opts to be passed to the tracer when starting or continuing the trace.",
+                 tracer_opts: "Any opts to be passed to the tracer when starting or continuing the trace.",
                  span_name: "The name to be used for the top level span."
                ]
              )

--- a/lib/span.ex
+++ b/lib/span.ex
@@ -91,14 +91,9 @@ defmodule Spandex.Span do
           {:ok, Span.t()}
           | {:error, [Optimal.error()]}
   def new(opts) do
-    case Optimal.validate(opts, @span_opts) do
-      {:ok, opts} ->
-        span = Map.merge(%Span{}, Enum.into(opts, %{}))
-        {:ok, span}
-
-      {:error, errors} ->
-        {:error, errors}
-    end
+    %Span{}
+    |> Map.merge(Enum.into(opts, %{}))
+    |> update(opts, @span_opts)
   end
 
   @doc """
@@ -136,6 +131,9 @@ defmodule Spandex.Span do
   ]
   ```
   """
+  @spec update(Span.t(), Keyword.t(), Optimal.Schema.t()) ::
+          {:ok, Span.t()}
+          | {:error, [Optimal.error()]}
   def update(span, opts, schema \\ Map.put(@span_opts, :required, [])) do
     opts_without_nils = Enum.reject(opts, fn {_key, value} -> is_nil(value) end)
 

--- a/lib/span.ex
+++ b/lib/span.ex
@@ -197,7 +197,7 @@ defmodule Spandex.Span do
     end)
   end
 
-  @spec validate_and_merge(t(), Keyword.t(), Optimal.schema()) ::
+  @spec validate_and_merge(Span.t(), Keyword.t(), Optimal.schema()) ::
           {:ok, Span.t()}
           | {:error, [Optimal.error()]}
   defp validate_and_merge(span, opts, schema) do

--- a/lib/span.ex
+++ b/lib/span.ex
@@ -2,6 +2,9 @@ defmodule Spandex.Span do
   @moduledoc """
   A container for all span data and metadata.
   """
+
+  alias Spandex.Span
+
   defstruct [
     :completion_time,
     :env,
@@ -13,6 +16,7 @@ defmodule Spandex.Span do
     :private,
     :resource,
     :service,
+    :services,
     :sql_query,
     :start,
     :tags,
@@ -22,57 +26,56 @@ defmodule Spandex.Span do
 
   @nested_opts [:error, :http, :sql_query]
 
-  @type timestamp :: term
-
-  @type t :: %__MODULE__{
-          completion_time: timestamp,
-          env: String.t(),
+  @type t :: %Span{
+          completion_time: Spandex.timestamp() | nil,
+          env: String.t() | nil,
           error: Keyword.t() | nil,
-          id: term,
-          name: String.t(),
-          parent_id: term,
-          private: Keyword.t(),
-          resource: String.t(),
-          service: atom,
           http: Keyword.t() | nil,
+          id: Spandex.id(),
+          name: String.t(),
+          parent_id: Spandex.id() | nil,
+          private: Keyword.t(),
+          resource: atom() | String.t(),
+          service: atom(),
+          services: Keyword.t() | nil,
           sql_query: Keyword.t() | nil,
-          start: timestamp,
-          trace_id: term,
+          start: Spandex.timestamp(),
           tags: Keyword.t() | nil,
-          type: atom
+          trace_id: Spandex.id(),
+          type: atom()
         }
 
   @span_opts Optimal.schema(
                opts: [
-                 id: :any,
-                 trace_id: :any,
-                 name: :string,
-                 http: :keyword,
-                 error: :keyword,
-                 completion_time: :any,
+                 completion_time: :integer,
                  env: :string,
-                 parent_id: :any,
+                 error: :keyword,
+                 http: :keyword,
+                 id: :integer,
+                 name: :string,
+                 parent_id: :integer,
                  private: :keyword,
                  resource: [:atom, :string],
                  service: :atom,
                  services: :keyword,
                  sql_query: :keyword,
-                 start: :any,
-                 type: :atom,
-                 tags: :keyword
+                 start: :integer,
+                 tags: :keyword,
+                 trace_id: :integer,
+                 type: :atom
                ],
                defaults: [
-                 tags: [],
+                 private: [],
                  services: [],
-                 private: []
+                 tags: []
                ],
                required: [
-                 :id,
-                 :trace_id,
-                 :name,
                  :env,
+                 :id,
+                 :name,
                  :service,
-                 :start
+                 :start,
+                 :trace_id
                ],
                extra_keys?: true
              )
@@ -84,8 +87,18 @@ defmodule Spandex.Span do
 
   #{Optimal.Doc.document(@span_opts)}
   """
+  @spec new(Keyword.t()) ::
+          {:ok, Span.t()}
+          | {:error, [Optimal.error()]}
   def new(opts) do
-    update(%__MODULE__{}, opts, @span_opts)
+    case Optimal.validate(opts, @span_opts) do
+      {:ok, opts} ->
+        span = Map.merge(%Span{}, Enum.into(opts, %{}))
+        {:ok, span}
+
+      {:error, errors} ->
+        {:error, errors}
+    end
   end
 
   @doc """
@@ -186,20 +199,24 @@ defmodule Spandex.Span do
     end)
   end
 
-  @spec validate_and_merge(t(), Keyword.t(), Optimal.schema()) :: t() | {:error, term}
+  @spec validate_and_merge(t(), Keyword.t(), Optimal.schema()) ::
+          {:ok, Span.t()}
+          | {:error, [Optimal.error()]}
   defp validate_and_merge(span, opts, schema) do
     case Optimal.validate(opts, schema) do
       {:ok, opts} ->
-        struct(span, opts)
+        {:ok, struct(span, opts)}
 
       {:error, errors} ->
         {:error, errors}
     end
   end
 
-  def child_of(%{id: parent_id} = parent, name, id, start, opts) do
-    child = %{parent | id: id, name: name, start: start, parent_id: parent_id}
-
+  @spec child_of(Span.t(), String.t(), Spandex.id(), Spandex.timestamp(), Keyword.t()) ::
+          {:ok, Span.t()}
+          | {:error, [Optimal.error()]}
+  def child_of(parent_span, name, id, start, opts) do
+    child = %Span{parent_span | id: id, name: name, start: start, parent_id: parent_span.id}
     update(child, opts)
   end
 

--- a/lib/spandex.ex
+++ b/lib/spandex.ex
@@ -269,8 +269,7 @@ defmodule Spandex do
     adapter = opts[:adapter]
 
     with {:ok, span} <- Span.child_of(current_span, name, adapter.span_id(), adapter.now(), opts),
-         {:ok, _trace} <-
-           strategy.put_trace(opts[:tracer], %{trace | stack: [span | trace.stack]}) do
+         {:ok, _trace} <- strategy.put_trace(opts[:tracer], %{trace | stack: [span | trace.stack]}) do
       Logger.metadata(span_id: span.id)
       {:ok, span}
     end

--- a/lib/spandex.ex
+++ b/lib/spandex.ex
@@ -4,71 +4,57 @@ defmodule Spandex do
   """
   require Logger
 
-  alias Spandex.Span
-  alias Spandex.Trace
+  alias Spandex.{
+    Span,
+    Trace,
+    Tracer
+  }
 
+  @typedoc "Used for Span and Trace IDs"
+  @type id :: non_neg_integer()
+
+  @typedoc "Unix timestamp in nanoseconds"
+  @type timestamp :: non_neg_integer()
+
+  @spec start_trace(binary(), Tracer.opts()) ::
+          {:ok, Trace.t()}
+          | {:error, :disabled}
+          | {:error, :trace_running}
+          | {:error, [Optimal.error()]}
   def start_trace(_, :disabled), do: {:error, :disabled}
 
   def start_trace(name, opts) do
     strategy = opts[:strategy]
 
     if strategy.get_trace(opts[:tracer]) do
-      _ = Logger.error("Tried to start a trace over top of another trace.")
+      Logger.error("Tried to start a trace over top of another trace.")
       {:error, :trace_running}
     else
-      adapter = opts[:adapter]
-      trace_id = adapter.trace_id()
-
-      name
-      |> span(opts, trace_id, adapter)
-      |> with_span(fn span ->
-        Logger.metadata(trace_id: trace_id, span_id: span.id)
-
-        trace = %Trace{
-          spans: [],
-          stack: [span],
-          id: trace_id
-        }
-
-        strategy.put_trace(opts[:tracer], trace)
-      end)
+      do_start_trace(name, opts)
     end
   end
 
+  @spec start_span(String.t(), Tracer.opts()) ::
+          {:ok, Span.t()}
+          | {:error, :disabled}
+          | {:error, :no_trace_context}
+          | {:error, [Optimal.error()]}
   def start_span(_, :disabled), do: {:error, :disabled}
 
   def start_span(name, opts) do
     strategy = opts[:strategy]
-    adapter = opts[:adapter]
 
     case strategy.get_trace(opts[:tracer]) do
-      nil ->
-        {:error, :no_trace_context}
-
-      %Trace{stack: [current_span | _]} = trace ->
-        current_span
-        |> Span.child_of(name, adapter.span_id(), adapter.now(), opts)
-        |> with_span(fn span ->
-          strategy.put_trace(opts[:tracer], %{trace | stack: [span | trace.stack]})
-
-          Logger.metadata(span_id: span.id)
-
-          {:ok, span}
-        end)
-
-      %Trace{stack: [], id: trace_id} = trace ->
-        name
-        |> span(opts, trace_id, adapter)
-        |> with_span(fn span ->
-          strategy.put_trace(opts[:tracer], %{trace | stack: [span]})
-
-          Logger.metadata(span_id: span.id)
-
-          {:ok, span}
-        end)
+      nil -> {:error, :no_trace_context}
+      trace -> do_start_span(name, trace, opts)
     end
   end
 
+  @spec update_span(Tracer.opts(), boolean()) ::
+          {:ok, Span.t()}
+          | {:error, :disabled}
+          | {:error, :no_trace_context}
+          | {:error, [Optimal.error()]}
   def update_span(opts, top? \\ false)
   def update_span(:disabled, _), do: {:error, :disabled}
 
@@ -76,32 +62,25 @@ defmodule Spandex do
     strategy = opts[:strategy]
 
     case strategy.get_trace(opts[:tracer]) do
-      nil ->
-        {:error, :no_trace_context}
-
-      %Trace{stack: stack} = trace ->
-        index =
-          if top? do
-            -1
-          else
-            0
-          end
-
-        new_stack = List.update_at(stack, index, &update_or_keep(&1, opts))
-
-        strategy.put_trace(opts[:tracer], %{trace | stack: new_stack})
-
-        {:ok, Enum.at(new_stack, index)}
+      nil -> {:error, :no_trace_context}
+      trace -> do_update_span(trace, opts, top?)
     end
   end
 
+  @spec update_top_span(Tracer.opts()) ::
+          {:ok, Span.t()}
+          | {:error, :disabled}
+          | {:error, :no_trace_context}
+          | {:error, [Optimal.error()]}
   def update_top_span(:disabled), do: {:error, :disabled}
 
-  def update_top_span(opts) do
-    top? = true
-    update_span(opts, top?)
-  end
+  def update_top_span(opts), do: update_span(opts, true)
 
+  @spec update_all_spans(Tracer.opts()) ::
+          {:ok, Trace.t()}
+          | {:error, :disabled}
+          | {:error, :no_trace_context}
+          | {:error, [Optimal.error()]}
   def update_all_spans(:disabled), do: {:error, :disabled}
 
   def update_all_spans(opts) do
@@ -113,13 +92,16 @@ defmodule Spandex do
 
       %Trace{stack: stack, spans: spans} = trace ->
         new_stack = Enum.map(stack, &update_or_keep(&1, opts))
-
         new_spans = Enum.map(spans, &update_or_keep(&1, opts))
-
         strategy.put_trace(opts[:tracer], %{trace | stack: new_stack, spans: new_spans})
     end
   end
 
+  @spec finish_trace(Tracer.opts()) ::
+          {:ok, Trace.t()}
+          | {:error, :disabled}
+          | {:error, :no_trace_context}
+          | {:error, [Optimal.error()]}
   def finish_trace(:disabled), do: {:error, :disabled}
 
   def finish_trace(opts) do
@@ -132,17 +114,18 @@ defmodule Spandex do
 
       %Trace{spans: spans, stack: stack} ->
         unfinished_spans = Enum.map(stack, &ensure_completion_time_set(&1, adapter))
-
         sender = opts[:sender] || adapter.default_sender()
-
-        spans
-        |> Kernel.++(unfinished_spans)
-        |> sender.send_spans()
-
+        sender.send_spans(spans ++ unfinished_spans)
         strategy.delete_trace(opts[:tracer])
     end
   end
 
+  @spec finish_span(Tracer.opts()) ::
+          {:ok, Span.t()}
+          | {:error, :disabled}
+          | {:error, :no_trace_context}
+          | {:error, :no_span_context}
+          | {:error, [Optimal.error()]}
   def finish_span(:disabled), do: {:error, :disabled}
 
   def finish_span(opts) do
@@ -158,26 +141,24 @@ defmodule Spandex do
 
       %Trace{stack: [span | tail], spans: spans} = trace ->
         finished_span = ensure_completion_time_set(span, adapter)
-
         strategy.put_trace(opts[:tracer], %{trace | stack: tail, spans: [finished_span | spans]})
         {:ok, finished_span}
     end
   end
 
-  defp ensure_completion_time_set(%Span{completion_time: nil} = span, adapter) do
-    update_or_keep(span, completion_time: adapter.now())
-  end
-
-  defp ensure_completion_time_set(%Span{} = span, _adapter), do: span
-
+  @spec span_error(Exception.t(), Enum.t(), Tracer.opts()) ::
+          {:ok, Span.t()}
+          | {:error, :disabled}
+          | {:error, :no_trace_context}
+          | {:error, [Optimal.error()]}
   def span_error(_error, _stacktrace, :disabled), do: {:error, :disabled}
 
   def span_error(exception, stacktrace, opts) do
     updates = [exception: exception, stacktrace: stacktrace]
-
     update_span(Keyword.put_new(opts, :error, updates))
   end
 
+  @spec current_trace_id(Tracer.opts()) :: Spandex.id() | nil
   def current_trace_id(:disabled), do: nil
 
   def current_trace_id(opts) do
@@ -192,6 +173,7 @@ defmodule Spandex do
     end
   end
 
+  @spec current_span_id(Tracer.opts()) :: Spandex.id() | nil
   def current_span_id(:disabled), do: nil
 
   def current_span_id(opts) do
@@ -201,6 +183,7 @@ defmodule Spandex do
     end
   end
 
+  @spec current_span(Tracer.opts()) :: Span.t() | nil
   def current_span(:disabled), do: nil
 
   def current_span(opts) do
@@ -213,53 +196,133 @@ defmodule Spandex do
     end
   end
 
+  @spec continue_trace(String.t(), Spandex.id(), Spandex.id(), Keyword.t()) ::
+          {:ok, %Trace{}}
+          | {:error, :disabled}
+          | {:error, :trace_already_present}
+          | {:error, [Optimal.error()]}
   def continue_trace(_, _, _, :disabled), do: {:error, :disabled}
 
   def continue_trace(name, trace_id, span_id, opts) do
     strategy = opts[:strategy]
-    adapter = opts[:adapter]
+    opts = Keyword.put(opts, :parent_id, span_id)
 
-    case strategy.get_trace(opts[:tracer]) do
-      nil ->
-        opts_with_parent = Keyword.put(opts, :parent_id, span_id)
-        top_span = span(name, opts_with_parent, trace_id, adapter)
-
-        strategy.put_trace(opts[:tracer], %Trace{id: trace_id, stack: [top_span], spans: []})
-
-      _ ->
-        {:error, :trace_already_present}
+    if strategy.get_trace(opts[:tracer]) do
+      {:error, :trace_already_present}
+    else
+      do_continue_trace(name, trace_id, opts)
     end
   end
 
+  @spec continue_trace_from_span(String.t(), Span.t(), Tracer.opts()) ::
+          {:ok, %Trace{}}
+          | {:error, :disabled}
+          | {:error, :trace_already_present}
+          | {:error, [Optimal.error()]}
   def continue_trace_from_span(_name, _span, :disabled), do: {:error, :disabled}
 
   def continue_trace_from_span(name, span, opts) do
     strategy = opts[:strategy]
-    adapter = opts[:adapter]
 
-    case strategy.get_trace(opts[:tracer]) do
-      nil ->
-        span
-        |> Span.child_of(name, adapter.span_id(), adapter.now(), opts)
-        |> with_span(fn span ->
-          strategy.put_trace(opts[:tracer], %Trace{
-            id: adapter.trace_id(),
-            stack: [span],
-            spans: []
-          })
-        end)
-
-      _ ->
-        {:error, :trace_already_present}
+    if strategy.get_trace(opts[:tracer]) do
+      {:error, :trace_already_present}
+    else
+      do_continue_trace_from_span(name, span, opts)
     end
   end
 
+  @spec distributed_context(Plug.Conn.t(), Tracer.opts()) ::
+          {:ok, map()}
+          | {:error, atom()}
+          | {:error, [Optimal.error()]}
   def distributed_context(_, :disabled), do: {:error, :disabled}
 
   def distributed_context(conn, opts) do
     adapter = opts[:adapter]
     adapter.distributed_context(conn, opts)
   end
+
+  # Private Helpers
+
+  defp do_continue_trace(name, trace_id, opts) do
+    strategy = opts[:strategy]
+    adapter = opts[:adapter]
+
+    with {:ok, top_span} <- span(name, opts, trace_id, adapter) do
+      trace = %Trace{id: trace_id, stack: [top_span], spans: []}
+      strategy.put_trace(opts[:tracer], trace)
+    end
+  end
+
+  defp do_continue_trace_from_span(name, span, opts) do
+    strategy = opts[:strategy]
+    adapter = opts[:adapter]
+
+    with {:ok, span} <- Span.child_of(span, name, adapter.span_id(), adapter.now(), opts) do
+      trace = %Trace{id: adapter.trace_id(), stack: [span], spans: []}
+      strategy.put_trace(opts[:tracer], trace)
+    end
+  end
+
+  defp do_start_span(name, %Trace{stack: [current_span | _]} = trace, opts) do
+    strategy = opts[:strategy]
+    adapter = opts[:adapter]
+
+    with {:ok, span} <- Span.child_of(current_span, name, adapter.span_id(), adapter.now(), opts),
+         {:ok, _trace} <-
+           strategy.put_trace(opts[:tracer], %{trace | stack: [span | trace.stack]}) do
+      Logger.metadata(span_id: span.id)
+      {:ok, span}
+    end
+  end
+
+  defp do_start_span(name, %Trace{stack: [], id: trace_id} = trace, opts) do
+    strategy = opts[:strategy]
+    adapter = opts[:adapter]
+
+    with {:ok, span} <- span(name, opts, trace_id, adapter),
+         {:ok, _trace} <- strategy.put_trace(opts[:tracer], %{trace | stack: [span]}) do
+      Logger.metadata(span_id: span.id)
+      {:ok, span}
+    end
+  end
+
+  defp do_start_trace(name, opts) do
+    strategy = opts[:strategy]
+    adapter = opts[:adapter]
+    trace_id = adapter.trace_id()
+
+    with {:ok, span} <- span(name, opts, trace_id, adapter) do
+      Logger.metadata(trace_id: trace_id, span_id: span.id)
+      trace = %Trace{spans: [], stack: [span], id: trace_id}
+      strategy.put_trace(opts[:tracer], trace)
+    end
+  end
+
+  defp do_update_span(%Trace{stack: stack} = trace, opts, true) do
+    strategy = opts[:strategy]
+    new_stack = List.update_at(stack, -1, &update_or_keep(&1, opts))
+
+    with {:ok, _trace} <- strategy.put_trace(opts[:tracer], %{trace | stack: new_stack}) do
+      {:ok, Enum.at(new_stack, -1)}
+    end
+  end
+
+  defp do_update_span(%Trace{stack: [current_span | other_spans]} = trace, opts, false) do
+    strategy = opts[:strategy]
+    updated_span = update_or_keep(current_span, opts)
+    new_stack = [updated_span | other_spans]
+
+    with {:ok, _trace} <- strategy.put_trace(opts[:tracer], %{trace | stack: new_stack}) do
+      {:ok, updated_span}
+    end
+  end
+
+  defp ensure_completion_time_set(%Span{completion_time: nil} = span, adapter) do
+    update_or_keep(span, completion_time: adapter.now())
+  end
+
+  defp ensure_completion_time_set(%Span{} = span, _adapter), do: span
 
   defp span(name, opts, trace_id, adapter) do
     opts
@@ -273,10 +336,7 @@ defmodule Spandex do
   defp update_or_keep(span, opts) do
     case Span.update(span, opts) do
       {:error, _} -> span
-      span -> span
+      {:ok, span} -> span
     end
   end
-
-  def with_span({:error, errors}, _fun), do: {:error, errors}
-  def with_span(span, fun), do: fun.(span)
 end

--- a/lib/spandex.ex
+++ b/lib/spandex.ex
@@ -10,8 +10,8 @@ defmodule Spandex do
     Tracer
   }
 
-  @typedoc "Used for Span and Trace IDs"
-  @type id :: non_neg_integer()
+  @typedoc "Used for Span and Trace IDs (type defined by adapters)"
+  @type id :: term()
 
   @typedoc "Unix timestamp in nanoseconds"
   @type timestamp :: non_neg_integer()

--- a/lib/trace.ex
+++ b/lib/trace.ex
@@ -11,6 +11,6 @@ defmodule Spandex.Trace do
   @type t :: %__MODULE__{
           stack: [Spandex.Span.t()],
           spans: [Spandex.Span.t()],
-          id: term
+          id: Spandex.id()
         }
 end

--- a/lib/tracer.ex
+++ b/lib/tracer.ex
@@ -25,10 +25,8 @@ defmodule Spandex.Tracer do
   @callback update_top_span(opts) :: tagged_tuple(Span.t())
   @callback finish_trace(opts) :: tagged_tuple(Trace.t())
   @callback finish_span(opts) :: tagged_tuple(Span.t())
-  @callback span_error(error :: Exception.t(), stacktrace :: [term], opts) ::
-              tagged_tuple(Span.t())
-  @callback continue_trace(span_name, trace_id :: term, span_id :: term, opts) ::
-              tagged_tuple(Trace.t())
+  @callback span_error(error :: Exception.t(), stacktrace :: [term], opts) :: tagged_tuple(Span.t())
+  @callback continue_trace(span_name, trace_id :: term, span_id :: term, opts) :: tagged_tuple(Trace.t())
   @callback continue_trace_from_span(span_name, span :: term, opts) :: tagged_tuple(Trace.t())
   @callback current_trace_id(opts) :: nil | Spandex.id()
   @callback current_span_id(opts) :: nil | Spandex.id()
@@ -60,14 +58,11 @@ defmodule Spandex.Tracer do
                    tracer: "Don't set manually. This option is passed automatically.",
                    sender:
                      "Once a trace is complete, it is sent using this module. Defaults to the `default_sender/0` of the selected adapter",
-                   service:
-                     "The default service name to use for spans declared without a service",
+                   service: "The default service name to use for spans declared without a service",
                    disabled?: "Allows for wholesale disabling a tracer",
-                   env:
-                     "A name used to identify the environment name, e.g `prod` or `development`",
+                   env: "A name used to identify the environment name, e.g `prod` or `development`",
                    services: "A mapping of service name to the default span types.",
-                   strategy:
-                     "The storage and tracing strategy. Currently only supports local process dictionary."
+                   strategy: "The storage and tracing strategy. Currently only supports local process dictionary."
                  ]
                )
 

--- a/lib/tracer.ex
+++ b/lib/tracer.ex
@@ -16,7 +16,7 @@ defmodule Spandex.Tracer do
 
   @type tagged_tuple(arg) :: {:ok, arg} | {:error, term}
   @type span_name() :: String.t()
-  @type opts :: Keyword.t()
+  @type opts :: Keyword.t() | :disabled
 
   @callback configure(opts) :: :ok
   @callback start_trace(span_name, opts) :: tagged_tuple(Trace.t())
@@ -30,8 +30,8 @@ defmodule Spandex.Tracer do
   @callback continue_trace(span_name, trace_id :: term, span_id :: term, opts) ::
               tagged_tuple(Trace.t())
   @callback continue_trace_from_span(span_name, span :: term, opts) :: tagged_tuple(Trace.t())
-  @callback current_trace_id(opts) :: nil | term
-  @callback current_span_id(opts) :: nil | term
+  @callback current_trace_id(opts) :: nil | Spandex.id()
+  @callback current_span_id(opts) :: nil | Spandex.id()
   @callback current_span(opts) :: nil | Span.t()
   @callback distributed_context(Plug.Conn.t(), opts) :: tagged_tuple(map)
   @macrocallback span(span_name, opts, do: Macro.t()) :: Macro.t()
@@ -73,7 +73,7 @@ defmodule Spandex.Tracer do
 
   @all_tracer_opts @tracer_opts
                    |> Optimal.merge(
-                     Spandex.Span.span_opts(),
+                     Span.span_opts(),
                      annotate: "Span Creation",
                      add_required?: false
                    )
@@ -96,8 +96,6 @@ defmodule Spandex.Tracer do
       @otp_app unquote(opts)[:otp_app] || raise("Must provide `otp_app` to `use Spandex.Tracer`")
 
       @behaviour Spandex.Tracer
-
-      alias Spandex.Tracer
 
       @opts Spandex.Tracer.tracer_opts()
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Spandex.Mixfile do
   def project do
     [
       app: :spandex,
-      version: "2.1.0-dev",
+      version: "2.0.0",
       elixir: "~> 1.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Spandex.Mixfile do
   def project do
     [
       app: :spandex,
-      version: "2.0.0",
+      version: "2.1.0-dev",
       elixir: "~> 1.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,

--- a/test/plug/add_context_test.exs
+++ b/test/plug/add_context_test.exs
@@ -55,8 +55,7 @@ defmodule Spandex.Plug.AddContextTest do
 
       :ok = Tracer.finish_trace()
 
-      %{trace_id: trace_id, type: type, http: http, resource: resource} =
-        Spandex.Test.Util.find_span("request")
+      %{trace_id: trace_id, type: type, http: http, resource: resource} = Spandex.Test.Util.find_span("request")
 
       assert trace_id == tid
       assert type == :web

--- a/test/plug/add_context_test.exs
+++ b/test/plug/add_context_test.exs
@@ -48,7 +48,7 @@ defmodule Spandex.Plug.AddContextTest do
           tracer_opts: []
         )
 
-      {:ok, expected_span} = Tracer.start_span("foobar")
+      assert {:ok, expected_span} = Tracer.start_span("foobar")
 
       assert Keyword.fetch!(Logger.metadata(), :trace_id) == tid
       assert Keyword.fetch!(Logger.metadata(), :span_id) == expected_span.id

--- a/test/plug/end_trace_test.exs
+++ b/test/plug/end_trace_test.exs
@@ -1,5 +1,6 @@
 defmodule Spandex.Plug.EndTraceTest do
   use ExUnit.Case
+  import ExUnit.CaptureLog
 
   alias Spandex.Plug.EndTrace
   alias Spandex.Plug.Utils
@@ -38,7 +39,12 @@ defmodule Spandex.Plug.EndTraceTest do
 
       assert is_nil(Tracer.current_trace_id())
 
-      {:error, :no_trace_context} = Tracer.finish_trace()
+      log =
+        capture_log(fn ->
+          assert {:error, :no_trace_context} = Tracer.finish_trace()
+        end)
+
+      assert String.contains?(log, "[error] Tried to finish a trace without an active trace.")
 
       %{trace_id: trace_id, http: http, error: error} = Spandex.Test.Util.find_span("request")
 
@@ -59,7 +65,12 @@ defmodule Spandex.Plug.EndTraceTest do
 
       assert is_nil(Tracer.current_trace_id())
 
-      {:error, :no_trace_context} = Tracer.finish_trace()
+      log =
+        capture_log(fn ->
+          assert {:error, :no_trace_context} = Tracer.finish_trace()
+        end)
+
+      assert String.contains?(log, "[error] Tried to finish a trace without an active trace.")
 
       %{trace_id: trace_id, http: http, error: error} = Spandex.Test.Util.find_span("request")
 

--- a/test/spandex_test.exs
+++ b/test/spandex_test.exs
@@ -1,0 +1,623 @@
+defmodule Spandex.Test.SpandexTest do
+  use ExUnit.Case, async: true
+  import ExUnit.CaptureLog
+
+  alias Spandex.Test.Util
+
+  alias Spandex.{
+    Span,
+    Trace
+  }
+
+  defmodule PdictSender do
+    def send_spans(spans) do
+      Process.put(:spans, spans)
+    end
+  end
+
+  @base_opts [
+    adapter: Spandex.TestAdapter,
+    strategy: Spandex.Strategy.Pdict,
+    env: "test"
+  ]
+
+  @span_opts [
+    service: :test_service,
+    resource: "test_resource"
+  ]
+
+  @runtime_error %RuntimeError{message: "something went wrong"}
+  @fake_stacktrace [:frame1, :frame2]
+
+  describe "Spandex.start_trace/2" do
+    test "creates a new Trace with a root Span with the given name" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{}} = Spandex.start_trace("root_span", opts)
+      assert %Span{name: "root_span"} = Spandex.current_span(@base_opts)
+    end
+
+    test "returns an error if there is already a trace in progress" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{}} = Spandex.start_trace("root_span", opts)
+
+      log =
+        capture_log(fn ->
+          assert {:error, :trace_running} = Spandex.start_trace("duplicate_span", opts)
+        end)
+
+      assert String.contains?(log, "[error] Tried to start a trace over top of another trace.")
+    end
+
+    test "returns an error if tracing is disabled" do
+      assert {:error, :disabled} = Spandex.start_trace("root_span", :disabled)
+    end
+
+    test "returns an error if invalid options are specified" do
+      assert {:error, validation_errors} = Spandex.start_trace("root_span", @base_opts)
+      assert {:service, "is required"} in validation_errors
+    end
+  end
+
+  describe "Spandex.start_span/2" do
+    test "creates a new Span under the active Span with the given name" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{id: trace_id}} = Spandex.start_trace("root_span", opts)
+      assert %Span{id: root_span_id} = Spandex.current_span(@base_opts)
+      assert {:ok, %Span{} = span} = Spandex.start_span("span_name", opts)
+      assert %Span{id: span_id, name: "span_name", parent_id: ^root_span_id} = span
+    end
+
+    test "returns an error if there is not a trace in progress" do
+      opts = @base_opts ++ @span_opts
+
+      log =
+        capture_log(fn ->
+          assert {:error, :no_trace_context} = Spandex.start_span("orphan_span", opts)
+        end)
+
+      assert String.contains?(log, "[error] Tried to start a span without an active trace.")
+    end
+
+    test "returns an error if tracing is disabled" do
+      assert {:error, :disabled} = Spandex.start_span("root_span", :disabled)
+    end
+
+    test "inherits service and resource from parent span if not specified" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{id: trace_id}} = Spandex.start_trace("root_span", opts)
+      assert {:ok, %Span{} = span} = Spandex.start_span("span_name", @base_opts)
+      assert %Span{name: "span_name", service: :test_service, resource: "test_resource"} = span
+    end
+
+    test "returns an error if invalid options are specified" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{id: trace_id}} = Spandex.start_trace("root_span", opts)
+      assert {:error, validation_errors} = Spandex.start_span("span_name", @base_opts ++ [type: "not an atom"])
+      assert {:type, "must be of type :atom"} in validation_errors
+    end
+  end
+
+  describe "Spandex.update_span/1" do
+    test "modifies the current span" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{id: trace_id}} = Spandex.start_trace("root_span", opts)
+      assert %Span{} = root_span = Spandex.current_span(@base_opts)
+      assert {:ok, %Span{} = span} = Spandex.start_span("span_name", opts)
+
+      updated_opts = Keyword.put(@base_opts, :sql_query, query: "SELECT * FROM users;")
+      assert {:ok, %Span{} = span} = Spandex.update_span(updated_opts)
+      assert ^span = Spandex.current_span(@base_opts)
+      assert %Span{sql_query: [query: "SELECT * FROM users;"]} = span
+
+      Spandex.finish_span(@base_opts)
+      assert ^root_span = Spandex.current_span(@base_opts)
+      assert root_span.sql_query == nil
+    end
+
+    test "returns an error if there is not a trace in progress" do
+      opts = @base_opts ++ @span_opts
+
+      log =
+        capture_log(fn ->
+          assert {:error, :no_trace_context} = Spandex.update_span(opts)
+        end)
+
+      assert String.contains?(log, "[error] Tried to update a span without an active trace.")
+    end
+
+    test "returns an error if there is not a span in progress" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{}} = Spandex.start_trace("root_span", opts)
+      assert %Span{id: root_span_id} = Spandex.current_span(@base_opts)
+      assert {:ok, %Span{id: ^root_span_id}} = Spandex.finish_span(@base_opts)
+
+      log =
+        capture_log(fn ->
+          assert {:error, :no_span_context} = Spandex.update_span(opts)
+        end)
+
+      assert String.contains?(log, "[error] Tried to update a span without an active span.")
+    end
+
+    test "returns an error if tracing is disabled" do
+      assert {:error, :disabled} = Spandex.update_span(:disabled)
+    end
+
+    # TODO: Currently, invalid opts are silently ignored. Should we change that?
+    @tag :skip
+    test "returns an error if invalid options are specified" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{id: trace_id}} = Spandex.start_trace("root_span", opts)
+      assert {:error, validation_errors} = Spandex.update_span(@base_opts ++ [type: "not an atom"])
+      assert {:type, "must be of type :atom"} in validation_errors
+    end
+  end
+
+  describe "Spandex.update_span/2" do
+    test "with false as the second argument, acts like update_span/1" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{id: trace_id}} = Spandex.start_trace("root_span", opts)
+      assert %Span{} = root_span = Spandex.current_span(@base_opts)
+      assert {:ok, %Span{} = span} = Spandex.start_span("span_name", opts)
+
+      updated_opts = Keyword.put(@base_opts, :sql_query, query: "SELECT * FROM users;")
+      assert {:ok, %Span{} = span} = Spandex.update_span(updated_opts)
+      assert ^span = Spandex.current_span(@base_opts)
+      assert %Span{sql_query: [query: "SELECT * FROM users;"]} = span
+
+      Spandex.finish_span(@base_opts)
+      assert ^root_span = Spandex.current_span(@base_opts)
+      assert root_span.sql_query == nil
+    end
+
+    test "with true as the second argument, acts like update_top_span/1" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{id: trace_id}} = Spandex.start_trace("root_span", opts)
+      assert %Span{id: root_span_id} = Spandex.current_span(@base_opts)
+      assert {:ok, %Span{id: span_id}} = Spandex.start_span("span_name", opts)
+
+      query = [query: "SELECT * FROM users;"]
+      updated_opts = Keyword.put(@base_opts, :sql_query, query)
+      assert {:ok, %Span{id: ^root_span_id}} = Spandex.update_top_span(updated_opts)
+      assert %Span{id: ^span_id, sql_query: nil} = Spandex.current_span(@base_opts)
+
+      Spandex.finish_span(@base_opts)
+      assert %Span{id: ^root_span_id, sql_query: ^query} = Spandex.current_span(@base_opts)
+    end
+  end
+
+  describe "Spandex.update_top_span/1" do
+    test "modifies the root span in the trace" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{id: trace_id}} = Spandex.start_trace("root_span", opts)
+      assert %Span{id: root_span_id} = Spandex.current_span(@base_opts)
+      assert {:ok, %Span{id: span_id}} = Spandex.start_span("span_name", opts)
+
+      query = [query: "SELECT * FROM users;"]
+      updated_opts = Keyword.put(@base_opts, :sql_query, query)
+      assert {:ok, %Span{id: ^root_span_id}} = Spandex.update_top_span(updated_opts)
+      assert %Span{id: ^span_id, sql_query: nil} = Spandex.current_span(@base_opts)
+
+      Spandex.finish_span(@base_opts)
+      assert %Span{id: ^root_span_id, sql_query: ^query} = Spandex.current_span(@base_opts)
+    end
+
+    test "returns an error if there is not a trace in progress" do
+      opts = @base_opts ++ @span_opts
+
+      log =
+        capture_log(fn ->
+          assert {:error, :no_trace_context} = Spandex.update_top_span(opts)
+        end)
+
+      assert String.contains?(log, "[error] Tried to update a span without an active trace.")
+    end
+
+    test "returns an error if tracing is disabled" do
+      assert {:error, :disabled} = Spandex.update_top_span(:disabled)
+    end
+
+    # TODO: Currently, invalid opts are silently ignored. Should we change that?
+    @tag :skip
+    test "returns an error if invalid options are specified" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{id: trace_id}} = Spandex.start_trace("root_span", opts)
+      assert {:error, validation_errors} = Spandex.update_top_span(@base_opts ++ [type: "not an atom"])
+      assert {:type, "must be of type :atom"} in validation_errors
+    end
+  end
+
+  describe "Spandex.update_all_spans/1" do
+    test "modifies each span in the trace" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{id: trace_id}} = Spandex.start_trace("root_span", opts)
+      assert %Span{id: root_span_id} = Spandex.current_span(@base_opts)
+      assert {:ok, %Span{id: span_id}} = Spandex.start_span("span_name", opts)
+
+      updated_opts = Keyword.put(@base_opts, :service, :updated_service)
+      assert {:ok, %Trace{id: ^trace_id}} = Spandex.update_all_spans(updated_opts)
+      assert %Span{id: ^span_id, service: :updated_service} = Spandex.current_span(@base_opts)
+
+      Spandex.finish_span(@base_opts)
+      assert %Span{id: ^root_span_id, service: :updated_service} = Spandex.current_span(@base_opts)
+    end
+
+    test "returns an error if there is not a trace in progress" do
+      opts = @base_opts ++ @span_opts
+
+      log =
+        capture_log(fn ->
+          assert {:error, :no_trace_context} = Spandex.update_all_spans(opts)
+        end)
+
+      assert String.contains?(log, "[error] Tried to update a span without an active trace.")
+    end
+
+    test "returns an error if tracing is disabled" do
+      assert {:error, :disabled} = Spandex.update_all_spans(:disabled)
+    end
+
+    # TODO: Currently, invalid opts are silently ignored. Should we change that?
+    @tag :skip
+    test "returns an error if invalid options are specified" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{id: trace_id}} = Spandex.start_trace("root_span", opts)
+      assert {:error, validation_errors} = Spandex.update_all_spans(@base_opts ++ [type: "not an atom"])
+      assert {:type, "must be of type :atom"} in validation_errors
+    end
+  end
+
+  describe "Spandex.finish_trace/1" do
+    test "sends all spans to the Adapter's default sender by default" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{id: trace_id}} = Spandex.start_trace("root_span", opts)
+      assert %Span{id: root_span_id} = Spandex.current_span(@base_opts)
+      assert {:ok, %Span{id: span_id}} = Spandex.start_span("span_name", opts)
+
+      assert :ok = Spandex.finish_trace(@base_opts)
+      spans = Util.sent_spans()
+      assert length(spans) == 2
+      assert Enum.any?(spans, fn span -> span.id == root_span_id end)
+      assert Enum.any?(spans, fn span -> span.id == span_id end)
+
+      assert nil == Spandex.current_span_id(@base_opts)
+      assert nil == Spandex.current_trace_id(@base_opts)
+    end
+
+    test "sends spans to an overridden sender" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{id: trace_id}} = Spandex.start_trace("root_span", opts)
+      assert %Span{id: root_span_id} = Spandex.current_span(@base_opts)
+      assert {:ok, %Span{id: span_id}} = Spandex.start_span("span_name", opts)
+
+      assert :ok == Spandex.finish_trace(@base_opts ++ [sender: PdictSender])
+      spans = Process.get(:spans)
+      assert length(spans) == 2
+      assert Enum.any?(spans, fn span -> span.id == root_span_id end)
+      assert Enum.any?(spans, fn span -> span.id == span_id end)
+
+      assert nil == Spandex.current_span_id(@base_opts)
+      assert nil == Spandex.current_trace_id(@base_opts)
+    end
+
+    test "ensures all spans have a completion time" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{id: trace_id}} = Spandex.start_trace("root_span", opts)
+      assert %Span{id: root_span_id} = Spandex.current_span(@base_opts)
+      assert {:ok, %Span{id: span_id}} = Spandex.start_span("span_name", opts)
+
+      assert :ok = Spandex.finish_trace(@base_opts)
+      spans = Util.sent_spans()
+      assert length(spans) == 2
+      assert Enum.all?(spans, fn span -> span.completion_time != nil end)
+    end
+
+    test "preserves existing completion times" do
+      now = :os.system_time(:nano_seconds)
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{}} = Spandex.start_trace("root_span", opts)
+      assert {:ok, %Span{id: span_id}} = Spandex.start_span("span_name", opts ++ [start: now - 10])
+      assert {:ok, %Span{id: ^span_id}} = Spandex.update_span(@base_opts ++ [completion_time: now - 9])
+      assert {:ok, %Span{id: ^span_id}} = Spandex.finish_span(@base_opts)
+
+      assert :ok = Spandex.finish_trace(@base_opts)
+      spans = Util.sent_spans()
+      assert length(spans) == 2
+      assert Enum.any?(spans, fn span -> span.id == span_id && span.completion_time == now - 9 end)
+    end
+
+    test "returns an error if there is not a trace in progress" do
+      log =
+        capture_log(fn ->
+          assert {:error, :no_trace_context} = Spandex.finish_trace(@base_opts)
+        end)
+
+      assert String.contains?(log, "[error] Tried to finish a trace without an active trace.")
+    end
+
+    test "returns an error if tracing is disabled" do
+      assert {:error, :disabled} = Spandex.finish_trace(:disabled)
+    end
+
+    # TODO: Currently, invalid opts are silently ignored. Should we change that?
+    @tag :skip
+    test "returns an error if invalid options are specified" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{id: trace_id}} = Spandex.start_trace("root_span", opts)
+      assert {:error, validation_errors} = Spandex.finish_trace(@base_opts ++ [type: "not an atom"])
+      assert {:type, "must be of type :atom"} in validation_errors
+    end
+  end
+
+  describe "Spandex.finish_span/1" do
+    test "sets the parent span as the current span" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{id: trace_id}} = Spandex.start_trace("root_span", opts)
+      assert %Span{id: root_span_id} = Spandex.current_span(@base_opts)
+      assert {:ok, %Span{id: span_id}} = Spandex.start_span("span_name", opts)
+
+      assert {:ok, %Span{id: ^span_id}} = Spandex.finish_span(@base_opts)
+      assert root_span_id == Spandex.current_span_id(@base_opts)
+      assert trace_id == Spandex.current_trace_id(@base_opts)
+    end
+
+    test "does not send the span immediately" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{}} = Spandex.start_trace("root_span", opts)
+      assert {:ok, %Span{id: span_id}} = Spandex.start_span("span_name", opts)
+
+      assert {:ok, %Span{id: ^span_id}} = Spandex.finish_span(@base_opts ++ [sender: PdictSender])
+      assert nil == Process.get(:spans)
+    end
+
+    test "ensures the span has a completion time" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{}} = Spandex.start_trace("root_span", opts)
+      assert {:ok, %Span{id: span_id}} = Spandex.start_span("span_name", opts)
+      assert {:ok, %Span{} = span} = Spandex.finish_span(@base_opts)
+      assert span.id == span_id
+      assert span.completion_time != nil
+    end
+
+    test "returns an error if there is not a trace in progress" do
+      log =
+        capture_log(fn ->
+          assert {:error, :no_trace_context} = Spandex.finish_span(@base_opts)
+        end)
+
+      assert String.contains?(log, "[error] Tried to finish a span without an active trace.")
+    end
+
+    test "returns an error if there is not a span in progress" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{}} = Spandex.start_trace("root_span", opts)
+      assert %Span{id: root_span_id} = Spandex.current_span(@base_opts)
+      assert {:ok, %Span{id: ^root_span_id}} = Spandex.finish_span(@base_opts)
+
+      log =
+        capture_log(fn ->
+          assert {:error, :no_span_context} = Spandex.finish_span(@base_opts)
+        end)
+
+      assert String.contains?(log, "[error] Tried to finish a span without an active span.")
+    end
+
+    test "returns an error if tracing is disabled" do
+      assert {:error, :disabled} = Spandex.finish_trace(:disabled)
+    end
+
+    # TODO: Currently, invalid opts are silently ignored. Should we change that?
+    @tag :skip
+    test "returns an error if invalid options are specified" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{id: trace_id}} = Spandex.start_trace("root_span", opts)
+      assert {:error, validation_errors} = Spandex.finish_span(@base_opts ++ [type: "not an atom"])
+      assert {:type, "must be of type :atom"} in validation_errors
+    end
+  end
+
+  describe "Spandex.span_error/3" do
+    test "updates the current span with error information" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{}} = Spandex.start_trace("root_span", opts)
+      assert {:ok, %Span{}} = Spandex.span_error(@runtime_error, @fake_stacktrace, @base_opts)
+      assert %Span{error: error} = Spandex.current_span(@base_opts)
+      assert [exception: %RuntimeError{}, stacktrace: stacktrace] = error
+      assert [_, _] = stacktrace
+    end
+
+    test "returns an error if there is not a trace in progress" do
+      opts = @base_opts ++ @span_opts
+
+      log =
+        capture_log(fn ->
+          assert {:error, :no_trace_context} = Spandex.span_error(@runtime_error, @fake_stacktrace, opts)
+        end)
+
+      assert String.contains?(log, "[error] Tried to update a span without an active trace.")
+    end
+
+    test "returns an error if there is not a span in progress" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{}} = Spandex.start_trace("root_span", opts)
+      assert {:ok, %Span{}} = Spandex.finish_span(@base_opts)
+
+      log =
+        capture_log(fn ->
+          assert {:error, :no_span_context} = Spandex.span_error(@runtime_error, @fake_stacktrace, @base_opts)
+        end)
+
+      assert String.contains?(log, "[error] Tried to update a span without an active span.")
+    end
+
+    test "returns an error if tracing is disabled" do
+      assert {:error, :disabled} = Spandex.span_error(@runtime_error, @fake_stacktrace, :disabled)
+    end
+
+    # TODO: Currently, invalid opts are silently ignored. Should we change that?
+    @tag :skip
+    test "returns an error if invalid options are specified" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{id: trace_id}} = Spandex.start_trace("root_span", opts)
+
+      assert {:error, validation_errors} =
+               Spandex.span_error(@runtime_error, @fake_stacktrace, @base_opts ++ [type: "not an atom"])
+
+      assert {:type, "must be of type :atom"} in validation_errors
+    end
+  end
+
+  describe "Spandex.current_trace_id/1" do
+    test "returns the active trace ID if a trace is active" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{id: trace_id}} = Spandex.start_trace("root_span", opts)
+      assert trace_id == Spandex.current_trace_id(@base_opts)
+    end
+
+    test "returns nil if no trace is active" do
+      assert nil == Spandex.current_trace_id(@base_opts)
+    end
+
+    test "returns nil if tracing is disabled" do
+      assert nil == Spandex.current_trace_id(:disabled)
+    end
+  end
+
+  describe "Spandex.current_span_id/1" do
+    test "returns the active span ID if a span is active" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{}} = Spandex.start_trace("root_span", opts)
+      assert {:ok, %Span{id: span_id}} = Spandex.start_span("span_name", @base_opts)
+      assert span_id == Spandex.current_span_id(@base_opts)
+    end
+
+    test "returns nil if no trace is active" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{}} = Spandex.start_trace("root_span", opts)
+      assert {:ok, %Span{}} = Spandex.finish_span(@base_opts)
+      assert nil == Spandex.current_span_id(@base_opts)
+    end
+
+    test "returns nil if no span is active" do
+      assert nil == Spandex.current_span_id(@base_opts)
+    end
+
+    test "returns nil if tracing is disabled" do
+      assert nil == Spandex.current_span_id(:disabled)
+    end
+  end
+
+  describe "Spandex.current_span/1" do
+    test "returns the active span if a span is active" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{}} = Spandex.start_trace("root_span", opts)
+      assert {:ok, %Span{id: span_id}} = Spandex.start_span("span_name", @base_opts)
+      assert %Span{id: ^span_id, name: "span_name"} = Spandex.current_span(@base_opts)
+    end
+
+    test "returns nil if no trace is active" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{}} = Spandex.start_trace("root_span", opts)
+      assert {:ok, %Span{}} = Spandex.finish_span(@base_opts)
+      assert nil == Spandex.current_span(@base_opts)
+    end
+
+    test "returns nil if no span is active" do
+      assert nil == Spandex.current_span(@base_opts)
+    end
+
+    test "returns nil if tracing is disabled" do
+      assert nil == Spandex.current_span(:disabled)
+    end
+  end
+
+  describe "Spandex.continue_trace/4" do
+    test "starts a new child span in an existing trace based on a specified name, trace ID and parent span ID" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{id: 123}} = Spandex.continue_trace("root_span", 123, 456, opts)
+      assert %Span{parent_id: 456, name: "root_span"} = Spandex.current_span(@base_opts)
+    end
+
+    test "returns an error if there is already a trace in progress" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{}} = Spandex.start_trace("root_span", opts)
+
+      log =
+        capture_log(fn ->
+          assert {:error, :trace_already_present} = Spandex.continue_trace("span_name", 123, 456, opts)
+        end)
+
+      assert String.contains?(log, "[error] Tried to continue a trace over top of another trace.")
+    end
+
+    test "returns an error if tracing is disabled" do
+      assert {:error, :disabled} == Spandex.continue_trace("span_name", 123, 456, :disabled)
+    end
+
+    test "returns an error if invalid options are specified" do
+      assert {:error, validation_errors} =
+               Spandex.continue_trace("span_name", 123, 456, @base_opts ++ [type: "not an atom"])
+
+      assert {:type, "must be of type :atom"} in validation_errors
+    end
+  end
+
+  describe "Spandex.continue_trace_from_span/3" do
+    test "returns a new trace based on a specified name and existing span" do
+      existing_span = %Span{id: 456, trace_id: 123, name: "existing"}
+      assert {:ok, %Trace{id: trace_id}} = Spandex.continue_trace_from_span("root_span", existing_span, @base_opts)
+      assert trace_id != 123
+      assert %Span{parent_id: 456, name: "root_span"} = Spandex.current_span(@base_opts)
+    end
+
+    test "returns an error if there is already a trace in progress" do
+      opts = @base_opts ++ @span_opts
+      assert {:ok, %Trace{}} = Spandex.start_trace("root_span", opts)
+      existing_span = %Span{id: 456, trace_id: 123, name: "existing"}
+
+      log =
+        capture_log(fn ->
+          assert {:error, :trace_already_present} =
+                   Spandex.continue_trace_from_span("root_span", existing_span, @base_opts)
+        end)
+
+      assert String.contains?(log, "[error] Tried to continue a trace over top of another trace.")
+    end
+
+    test "returns an error if tracing is disabled" do
+      existing_span = %Span{id: 456, trace_id: 123, name: "existing"}
+      assert {:error, :disabled} == Spandex.continue_trace_from_span("root_span", existing_span, :disabled)
+    end
+
+    test "returns an error if invalid options are specified" do
+      existing_span = %Span{id: 456, trace_id: 123, name: "existing"}
+
+      assert {:error, validation_errors} =
+               Spandex.continue_trace_from_span("span_name", existing_span, @base_opts ++ [type: "not an atom"])
+
+      assert {:type, "must be of type :atom"} in validation_errors
+    end
+  end
+
+  describe "Spandex.distributed_context/2" do
+    test "returns a distributed context representation" do
+      conn =
+        :get
+        |> Plug.Test.conn("/")
+        |> Plug.Conn.put_req_header("x-test-trace-id", "1234")
+        |> Plug.Conn.put_req_header("x-test-parent-id", "5678")
+
+      assert {:ok, %{trace_id: 1234, parent_id: 5678}} = Spandex.distributed_context(conn, @base_opts)
+    end
+
+    test "returns an error if distributed tracing headers are not present" do
+      conn = Plug.Test.conn(:get, "/")
+      assert {:error, :no_distributed_trace} = Spandex.distributed_context(conn, @base_opts)
+    end
+
+    test "returns an error if tracing is disabled" do
+      conn = Plug.Test.conn(:get, "/")
+      assert {:error, :disabled} == Spandex.distributed_context(conn, :disabled)
+    end
+  end
+end


### PR DESCRIPTION
When running `mix dialyzer`, I was getting the following errors:

```
lib/span.ex:87: Function new/1 has no local return
lib/span.ex:88: The call 'Elixir.Spandex.Span':update(#{'__struct__'=>'Elixir.Spandex.Span', 'completion_time'=>'nil', 'env'=>'nil', 'error'=>'nil', 'http'=>'nil', 'id'=>'nil', 'name'=>'nil', 'parent_id'=>'nil', 'private'=>'nil', 'resource'=>'nil', 'service'=>'nil', 'sql_query'=>'nil', 'start'=>'nil', 'tags'=>'nil', 'trace_id'=>'nil', 'type'=>'nil'},_opts@1::any(),#{'__struct__':='Elixir.Optimal
.Schema', 'annotations':=[], 'custom':=[], 'defaults':=[{'private',[]} | {'services',[]} | {'tags',[]},...], 'describe':=[], 'extra_keys?':='true', 'opts':=[atom(),...], 'required':=['env' | 'id' | 'name' | 'service' | 'start' | 'trace_id',...], 'types':=[{atom(),'any' | 'atom' | 'keyword' | 'string' | ['atom' | 'string',...]},...]}) will never return since it differs in the 1st argument from th
e success typing arguments: (#{'__struct__':='Elixir.Spandex.Span', 'completion_time':=_, 'env':=binary(), 'error':='nil' | [{_,_}], 'http':='nil' | [{_,_}], 'id':=_, 'name':=binary(), 'parent_id':=_, 'private':=[{_,_}], 'resource':=binary(), 'service':=atom(), 'sql_query':='nil' | [{_,_}], 'start':=_, 'tags':='nil' | [{_,_}], 'trace_id':=_, 'type':=atom()},any(),#{'__struct__':='Elixir.Optimal.
Schema', 'annotations':=[{_,_}], 'custom':=[{_,_}], 'defaults':=[{_,_}], 'describe':=[{_,_}], 'extra_keys?':=boolean(), 'opts':=[atom()], 'required':=[atom()], 'types':=[{_,_}]})
lib/spandex.ex:264: Function span/4 has no local return
```

Those are now resolved, but when I started to tug on that thread, the changes ended up leading me all over the place and I'm sorry for the huge PR. 

As mentioned in #62, this also standardizes on `{:ok, result}` tuples wherever an `{:error, reason}` tuple is possible. For that reason, I'm proposing a version bump from `2.0.0` to `2.1.0` since it's a small breaking change to the API, but my guess is that people probably aren't often using the return values from these functions in practice, as long as the right things are getting passed around inside Spandex.