### PR TITLE
Fix broken `Tracer.configure(disabled?: true)`

### DIFF
--- a/test/configure_test.exs
+++ b/test/configure_test.exs
@@ -1,0 +1,21 @@
+defmodule Spandex.Test.ConfigureTest do
+  use ExUnit.Case, async: false
+
+  alias Spandex.Test.Util
+  require Spandex.Test.Support.Tracer
+  alias Spandex.Test.Support.Tracer
+
+  test "disabled tracer should not have results" do
+    original_env = Application.get_env(:spandex, Tracer)
+    assert :ok = Tracer.configure(disabled?: true)
+
+    Tracer.trace "my_trace" do
+    end
+
+    span = Util.can_fail(fn -> Util.find_span("my_trace") end)
+
+    assert(span == nil)
+
+    Tracer.configure(original_env)
+  end
+end


### PR DESCRIPTION
Currently, even when `Tracer.configure(disabled?: true)` is called, the spandex is not disabled.

There is another issue that calls of `trace_start` and `span_start` after dynamic configuration of tracer  using `Tracer.configure(service: :app, adapter: ..., disabled?: true)` will cause exception like:
```
    ** (EXIT) an exception was raised:
        ** (ArgumentError) Opt Validation Error: service - is required, adapter - is required
            (optimal) lib/optimal.ex:44: Optimal.validate!/2
            (mikoto) lib/mikoto/tracer.ex:2: Mikoto.Tracer.config/2
            (mikoto) lib/mikoto/tracer.ex:2: Mikoto.Tracer.start_span/2
```

This is because the option is not `Application.put_env` when `disabled?: true`.

This patch fixes the issue.