### PR TITLE
Introduce SpanContext for distributed tracing

### DIFF
--- a/lib/adapter.ex
+++ b/lib/adapter.ex
@@ -3,7 +3,9 @@ defmodule Spandex.Adapter do
   The callbacks required to implement the Spandex.Adapter behaviour.
   """
 
-  @callback distributed_context(Plug.Conn.t(), Keyword.t()) :: {:ok, term} | {:error, term}
+  @callback distributed_context(Plug.Conn.t(), Keyword.t()) ::
+              {:ok, Spandex.SpanContext.t()}
+              | {:error, atom()}
   @callback trace_id() :: Spandex.id()
   @callback span_id() :: Spandex.id()
   @callback now() :: Spandex.timestamp()

--- a/lib/plug/start_trace.ex
+++ b/lib/plug/start_trace.ex
@@ -6,6 +6,7 @@ defmodule Spandex.Plug.StartTrace do
   @behaviour Plug
 
   alias Spandex.Plug.Utils
+  alias Spandex.SpanContext
 
   @init_opts Optimal.schema(
                opts: [
@@ -55,14 +56,12 @@ defmodule Spandex.Plug.StartTrace do
     tracer_opts = opts[:tracer_opts]
 
     case tracer.distributed_context(conn, tracer_opts) do
-      {:ok, %{trace_id: trace_id, parent_id: parent_id}} ->
-        tracer.continue_trace("request", trace_id, parent_id, tracer_opts)
-
+      {:ok, %SpanContext{} = span_context} ->
+        tracer.continue_trace("request", span_context, tracer_opts)
         Utils.trace(conn, true)
 
       {:error, :no_distributed_trace} ->
         tracer.start_trace(opts[:span_name], tracer_opts)
-
         Utils.trace(conn, true)
 
       _ ->

--- a/lib/span.ex
+++ b/lib/span.ex
@@ -51,9 +51,9 @@ defmodule Spandex.Span do
                  env: :string,
                  error: :keyword,
                  http: :keyword,
-                 id: :integer,
+                 id: :any,
                  name: :string,
-                 parent_id: :integer,
+                 parent_id: :any,
                  private: :keyword,
                  resource: [:atom, :string],
                  service: :atom,
@@ -61,7 +61,7 @@ defmodule Spandex.Span do
                  sql_query: :keyword,
                  start: :integer,
                  tags: :keyword,
-                 trace_id: :integer,
+                 trace_id: :any,
                  type: :atom
                ],
                defaults: [

--- a/lib/span_context.ex
+++ b/lib/span_context.ex
@@ -1,0 +1,23 @@
+defmodule Spandex.SpanContext do
+  @moduledoc """
+  From the [OpenTracing specification]:
+  > Each SpanContext encapsulates the following state:
+  > * Any OpenTracing-implementation-dependent state (for example, trace and span ids) needed to refer to a distinct Span across a process boundary
+  > * Baggage Items, which are just key:value pairs that cross process boundaries
+
+  [OpenTracing specification]: https://github.com/opentracing/specification/blob/master/specification.md
+  """
+
+  @typedoc @moduledoc
+  @type t :: %__MODULE__{
+          trace_id: Spandex.id(),
+          parent_id: Spandex.id(),
+          priority: integer(),
+          baggage: Keyword.t()
+        }
+
+  defstruct trace_id: nil,
+            parent_id: nil,
+            priority: 1,
+            baggage: []
+end

--- a/lib/spandex.ex
+++ b/lib/spandex.ex
@@ -47,7 +47,6 @@ defmodule Spandex do
 
     case strategy.get_trace(opts[:trace_key]) do
       {:error, :no_trace_context} = error ->
-        Logger.error("Tried to start a span without an active trace.")
         error
 
       {:error, _} = error ->
@@ -72,11 +71,9 @@ defmodule Spandex do
 
     case strategy.get_trace(opts[:trace_key]) do
       {:error, :no_trace_context} = error ->
-        Logger.error("Tried to update a span without an active trace.")
         error
 
       {:ok, %Trace{stack: []}} ->
-        Logger.error("Tried to update a span without an active span.")
         {:error, :no_span_context}
 
       {:ok, trace} ->
@@ -108,7 +105,6 @@ defmodule Spandex do
 
     case strategy.get_trace(opts[:trace_key]) do
       {:error, :no_trace_context} = error ->
-        Logger.error("Tried to update a span without an active trace.")
         error
 
       {:ok, %Trace{stack: stack, spans: spans} = trace} ->
@@ -164,7 +160,6 @@ defmodule Spandex do
 
     case strategy.get_trace(opts[:trace_key]) do
       {:error, :no_trace_context} = error ->
-        Logger.error("Tried to finish a span without an active trace.")
         error
 
       {:ok, %Trace{stack: []}} ->

--- a/lib/trace.ex
+++ b/lib/trace.ex
@@ -2,15 +2,24 @@ defmodule Spandex.Trace do
   @moduledoc """
   A representation of an ongoing trace.
 
-  `stack` represents all parent spans, while `spans` represents
-  all completed spans.
-
+  * `baggage`: Key-value metadata about the overall trace (propagated across distributed service)
+  * `id`: The trace ID, which consistently refers to this trace across distributed services
+  * `priority`: The trace sampling priority for this trace (propagated across distributed services)
+  * `spans`: The set of completed spans for this trace from this proces
+  * `stack`: The stack of active parent spans
   """
-  defstruct [:stack, :spans, :id, :start]
+  defstruct baggage: [],
+            id: nil,
+            priority: 1,
+            spans: [],
+            stack: []
 
+  @typedoc @moduledoc
   @type t :: %__MODULE__{
-          stack: [Spandex.Span.t()],
+          baggage: Keyword.t(),
+          id: Spandex.id(),
+          priority: integer(),
           spans: [Spandex.Span.t()],
-          id: Spandex.id()
+          stack: [Spandex.Span.t()]
         }
 end

--- a/lib/tracer.ex
+++ b/lib/tracer.ex
@@ -11,10 +11,13 @@ defmodule Spandex.Tracer do
   ```
   """
 
-  alias Spandex.Trace
-  alias Spandex.Span
+  alias Spandex.{
+    Span,
+    SpanContext,
+    Trace
+  }
 
-  @type tagged_tuple(arg) :: {:ok, arg} | {:error, term}
+  @type tagged_tuple(arg) :: {:ok, arg} | {:error, term()}
   @type span_name() :: String.t()
   @type opts :: Keyword.t() | :disabled
 
@@ -26,7 +29,7 @@ defmodule Spandex.Tracer do
   @callback finish_trace(opts) :: tagged_tuple(Trace.t())
   @callback finish_span(opts) :: tagged_tuple(Span.t())
   @callback span_error(error :: Exception.t(), stacktrace :: [term], opts) :: tagged_tuple(Span.t())
-  @callback continue_trace(span_name, trace_id :: term, span_id :: term, opts) :: tagged_tuple(Trace.t())
+  @callback continue_trace(span_name :: String.t(), trace_context :: SpanContext.t(), opts) :: tagged_tuple(Trace.t())
   @callback continue_trace_from_span(span_name, span :: term, opts) :: tagged_tuple(Trace.t())
   @callback current_trace_id(opts) :: nil | Spandex.id()
   @callback current_span_id(opts) :: nil | Spandex.id()
@@ -193,8 +196,8 @@ defmodule Spandex.Tracer do
       end
 
       @impl Spandex.Tracer
-      def continue_trace(span_name, trace_id, span_id, opts \\ []) do
-        Spandex.continue_trace(span_name, trace_id, span_id, config(opts, @otp_app))
+      def continue_trace(span_name, span_context, opts \\ []) do
+        Spandex.continue_trace(span_name, span_context, config(opts, @otp_app))
       end
 
       @impl Spandex.Tracer

--- a/test/spandex_test.exs
+++ b/test/spandex_test.exs
@@ -71,13 +71,7 @@ defmodule Spandex.Test.SpandexTest do
 
     test "returns an error if there is not a trace in progress" do
       opts = @base_opts ++ @span_opts
-
-      log =
-        capture_log(fn ->
-          assert {:error, :no_trace_context} = Spandex.start_span("orphan_span", opts)
-        end)
-
-      assert String.contains?(log, "[error] Tried to start a span without an active trace.")
+      assert {:error, :no_trace_context} = Spandex.start_span("orphan_span", opts)
     end
 
     test "returns an error if tracing is disabled" do
@@ -119,14 +113,7 @@ defmodule Spandex.Test.SpandexTest do
     end
 
     test "returns an error if there is not a trace in progress" do
-      opts = @base_opts ++ @span_opts
-
-      log =
-        capture_log(fn ->
-          assert {:error, :no_trace_context} = Spandex.update_span(opts)
-        end)
-
-      assert String.contains?(log, "[error] Tried to update a span without an active trace.")
+      assert {:error, :no_trace_context} = Spandex.update_span(@base_opts ++ @span_opts)
     end
 
     test "returns an error if there is not a span in progress" do
@@ -134,13 +121,7 @@ defmodule Spandex.Test.SpandexTest do
       assert {:ok, %Trace{}} = Spandex.start_trace("root_span", opts)
       assert %Span{id: root_span_id} = Spandex.current_span(@base_opts)
       assert {:ok, %Span{id: ^root_span_id}} = Spandex.finish_span(@base_opts)
-
-      log =
-        capture_log(fn ->
-          assert {:error, :no_span_context} = Spandex.update_span(opts)
-        end)
-
-      assert String.contains?(log, "[error] Tried to update a span without an active span.")
+      assert {:error, :no_span_context} = Spandex.update_span(opts)
     end
 
     test "returns an error if tracing is disabled" do
@@ -210,13 +191,7 @@ defmodule Spandex.Test.SpandexTest do
 
     test "returns an error if there is not a trace in progress" do
       opts = @base_opts ++ @span_opts
-
-      log =
-        capture_log(fn ->
-          assert {:error, :no_trace_context} = Spandex.update_top_span(opts)
-        end)
-
-      assert String.contains?(log, "[error] Tried to update a span without an active trace.")
+      assert {:error, :no_trace_context} = Spandex.update_top_span(opts)
     end
 
     test "returns an error if tracing is disabled" do
@@ -253,13 +228,7 @@ defmodule Spandex.Test.SpandexTest do
 
     test "returns an error if there is not a trace in progress" do
       opts = @base_opts ++ @span_opts
-
-      log =
-        capture_log(fn ->
-          assert {:error, :no_trace_context} = Spandex.update_all_spans(opts)
-        end)
-
-      assert String.contains?(log, "[error] Tried to update a span without an active trace.")
+      assert {:error, :no_trace_context} = Spandex.update_all_spans(opts)
     end
 
     test "returns an error if tracing is disabled" do
@@ -398,12 +367,7 @@ defmodule Spandex.Test.SpandexTest do
     end
 
     test "returns an error if there is not a trace in progress" do
-      log =
-        capture_log(fn ->
-          assert {:error, :no_trace_context} = Spandex.finish_span(@base_opts)
-        end)
-
-      assert String.contains?(log, "[error] Tried to finish a span without an active trace.")
+      assert {:error, :no_trace_context} = Spandex.finish_span(@base_opts)
     end
 
     test "returns an error if there is not a span in progress" do
@@ -448,26 +412,14 @@ defmodule Spandex.Test.SpandexTest do
 
     test "returns an error if there is not a trace in progress" do
       opts = @base_opts ++ @span_opts
-
-      log =
-        capture_log(fn ->
-          assert {:error, :no_trace_context} = Spandex.span_error(@runtime_error, @fake_stacktrace, opts)
-        end)
-
-      assert String.contains?(log, "[error] Tried to update a span without an active trace.")
+      assert {:error, :no_trace_context} = Spandex.span_error(@runtime_error, @fake_stacktrace, opts)
     end
 
     test "returns an error if there is not a span in progress" do
       opts = @base_opts ++ @span_opts
       assert {:ok, %Trace{}} = Spandex.start_trace("root_span", opts)
       assert {:ok, %Span{}} = Spandex.finish_span(@base_opts)
-
-      log =
-        capture_log(fn ->
-          assert {:error, :no_span_context} = Spandex.span_error(@runtime_error, @fake_stacktrace, @base_opts)
-        end)
-
-      assert String.contains?(log, "[error] Tried to update a span without an active span.")
+      assert {:error, :no_span_context} = Spandex.span_error(@runtime_error, @fake_stacktrace, @base_opts)
     end
 
     test "returns an error if tracing is disabled" do

--- a/test/support/sender.ex
+++ b/test/support/sender.ex
@@ -3,7 +3,7 @@ defmodule Spandex.TestSender do
   Simply sends the data that would have been sent to the service to self() as a message
   so that the test can assert on payloads that would have been sent to the service
   """
-  def send_spans(spans) do
-    send(self(), {:sent_spans, spans})
+  def send_spans(spans, opts \\ []) do
+    send(self(), {:sent_spans, spans, opts})
   end
 end

--- a/test/support/sender.ex
+++ b/test/support/sender.ex
@@ -3,7 +3,7 @@ defmodule Spandex.TestSender do
   Simply sends the data that would have been sent to the service to self() as a message
   so that the test can assert on payloads that would have been sent to the service
   """
-  def send_spans(spans, opts \\ []) do
-    send(self(), {:sent_spans, spans, opts})
+  def send_trace(trace, _opts \\ []) do
+    send(self(), {:sent_trace, trace})
   end
 end

--- a/test/support/util.ex
+++ b/test/support/util.ex
@@ -12,9 +12,7 @@ defmodule Spandex.Test.Util do
   end
 
   def find_span(fun) when is_function(fun) do
-    sent_spans()
-    |> elem(0)
-    |> Enum.find(fun)
+    Enum.find(sent_spans(), fun)
   end
 
   def find_span(name, index) when is_bitstring(name) do
@@ -23,16 +21,15 @@ defmodule Spandex.Test.Util do
 
   def find_span(fun, index) when is_function(fun) do
     sent_spans()
-    |> elem(0)
     |> Enum.filter(fun)
     |> Enum.at(index)
   end
 
   def sent_spans(timeout \\ 500) do
     receive do
-      {:sent_spans, spans, opts} ->
-        send(self(), {:sent_spans, spans, opts})
-        {spans, opts}
+      {:sent_trace, trace} ->
+        send(self(), {:sent_trace, trace})
+        trace.spans
     after
       timeout ->
         raise "No spans sent"

--- a/test/support/util.ex
+++ b/test/support/util.ex
@@ -12,7 +12,9 @@ defmodule Spandex.Test.Util do
   end
 
   def find_span(fun) when is_function(fun) do
-    Enum.find(sent_spans(), fun)
+    sent_spans()
+    |> elem(0)
+    |> Enum.find(fun)
   end
 
   def find_span(name, index) when is_bitstring(name) do
@@ -21,15 +23,16 @@ defmodule Spandex.Test.Util do
 
   def find_span(fun, index) when is_function(fun) do
     sent_spans()
+    |> elem(0)
     |> Enum.filter(fun)
     |> Enum.at(index)
   end
 
   def sent_spans() do
     receive do
-      {:sent_spans, spans} ->
-        send(self(), {:sent_spans, spans})
-        spans
+      {:sent_spans, spans, opts} ->
+        send(self(), {:sent_spans, spans, opts})
+        {spans, opts}
     after
       5000 ->
         raise "No spans sent"

--- a/test/support/util.ex
+++ b/test/support/util.ex
@@ -28,13 +28,13 @@ defmodule Spandex.Test.Util do
     |> Enum.at(index)
   end
 
-  def sent_spans() do
+  def sent_spans(timeout \\ 500) do
     receive do
       {:sent_spans, spans, opts} ->
         send(self(), {:sent_spans, spans, opts})
         {spans, opts}
     after
-      5000 ->
+      timeout ->
         raise "No spans sent"
     end
   end


### PR DESCRIPTION
Related to https://github.com/spandex-project/spandex_datadog/pull/3, this creates a new `Spandex.SpanContext` struct that we can use to control the API around distributed trace contexts.

Resolves #72 