### PR TITLE
Don't require that the env be specified

### DIFF
--- a/lib/span.ex
+++ b/lib/span.ex
@@ -70,7 +70,6 @@ defmodule Spandex.Span do
                  tags: []
                ],
                required: [
-                 :env,
                  :id,
                  :name,
                  :service,

--- a/lib/tracer.ex
+++ b/lib/tracer.ex
@@ -49,7 +49,6 @@ defmodule Spandex.Tracer do
                  required: [:adapter, :service],
                  defaults: [
                    disabled?: false,
-                   env: "unknown",
                    services: [],
                    strategy: Spandex.Strategy.Pdict
                  ],


### PR DESCRIPTION
When working on the `spandex_datadog` sender, I realized that we don't currently have a way to _not_ send the `env` with the spans. With Datadog, if you don't specify an `env` in the application like this, it will use the `env` configured in the trace collector agent. This PR makes it possible to do so, and I have another PR ready on the `spandex_dagtadog` repo that supports this from that end.