### PR TITLE
Add warning about use of Mix.env/0 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ config :my_app, MyApp.Tracer,
 Or at runtime, by calling `configure/1` (usually in your application's startup)
 
 ```elixir
-MyApp.Tracer.configure(disabled?: Mix.env() == :test)
+MyApp.Tracer.configure(disabled?: System.get_env("TRACE") != "true")
 ```
 
 For more information on Tracer configuration, view the docs for


### PR DESCRIPTION
Using `Mix.env/0` in the configuration example is likely to lead to issues when someone tries to use code like that in a release, as Mix is not intended (and basically does not work) in releases. This PR adds a warning and alternative option for the same config, but it may be preferable to remove the use of `Mix.env/0` entirely and use something else as an example.

Nice work!