### PR TITLE
Add inject_context and current_context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No unreleased changes currently.
+
+[NEXT]: https://github.com/spandex-project/spandex/compare/vNEXT...v2.2.0
+
+### Added
+
+- `Spandex.current_context/1` and `Spandex.Tracer.current_context/1` functions,
+  which get a `Spandex.SpanContext` struct based on the current context.
+
+- `Spandex.inject_context/3` and `Spandex.Tracer.inject_context/3` functions,
+  which inject the current distributed tracing context into a list of HTTP
+  headers.
+
+### Changed
+
+- The `Spandex.Adapter` behaviour now requires an `inject_context/3` callback,
+  which encodes a `Spandex.SpanContext` as HTTP headers for distributed
+  tracing.
 
 ## [2.2.0]
+
+[2.2.0]: https://github.com/spandex-project/spandex/compare/v2.2.0...v2.1.0
 
 ### Added
 - The `Spandex.Trace` struct now includes `priority` and `baggage` fields, to
@@ -39,6 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.1.0]
 It is recommended to reread the README, to see the upgrade guide and understand the changes.
 
+[2.1.0]: https://github.com/spandex-project/spandex/compare/v2.1.0...v1.6.1
+
 ### Added
 - Massive changes, including separating adapters into their own repositories
 
@@ -49,10 +69,16 @@ It is recommended to reread the README, to see the upgrade guide and understand 
 - Adapters now exist in their own repositories
 
 ## [1.6.1] - 2018-06-04
+
+[1.6.1]: https://github.com/spandex-project/spandex/compare/v1.6.1...v1.6.0
+
 ### Added
 - `private` key, when updating spans, for non-inheriting meta
 
 ## [1.6.0] - 2018-06-04
+
+[1.6.0]: https://github.com/spandex-project/spandex/compare/v1.6.0...v1.5.0
+
 ### Added
 - Storage strategy behaviour
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Spandex.current_context/1` and `Spandex.Tracer.current_context/1` functions,
   which get a `Spandex.SpanContext` struct based on the current context.
 
-- `Spandex.inject_context/3` and `Spandex.Tracer.inject_context/3` functions,
-  which inject the current distributed tracing context into a list of HTTP
-  headers.
+- `Spandex.inject_context/3` and `Spandex.Tracer.inject_context/2` functions,
+  which inject a distributed tracing context into a list of HTTP headers.
 
 ### Changed
 

--- a/lib/adapter.ex
+++ b/lib/adapter.ex
@@ -6,6 +6,7 @@ defmodule Spandex.Adapter do
   @callback distributed_context(Plug.Conn.t(), Keyword.t()) ::
               {:ok, Spandex.SpanContext.t()}
               | {:error, atom()}
+  @callback inject_context(Spandex.headers(), Spandex.SpanContext.t(), Keyword.t()) :: Spandex.headers()
   @callback trace_id() :: Spandex.id()
   @callback span_id() :: Spandex.id()
   @callback now() :: Spandex.timestamp()

--- a/lib/tracer.ex
+++ b/lib/tracer.ex
@@ -41,7 +41,7 @@ defmodule Spandex.Tracer do
               | {:error, :no_trace_context}
               | {:error, [Optimal.error()]}
   @callback distributed_context(Plug.Conn.t(), opts) :: tagged_tuple(map)
-  @callback inject_context(Spandex.headers(), SpanContext.t(), opts) :: Spandex.headers()
+  @callback inject_context(Spandex.headers(), opts) :: Spandex.headers()
   @macrocallback span(span_name, opts, do: Macro.t()) :: Macro.t()
   @macrocallback trace(span_name, opts, do: Macro.t()) :: Macro.t()
 
@@ -250,7 +250,8 @@ defmodule Spandex.Tracer do
       end
 
       @impl Spandex.Tracer
-      def inject_context(headers, %SpanContext{} = span_context, opts \\ []) do
+      def inject_context(headers, opts \\ []) do
+        span_context = current_context(opts)
         Spandex.inject_context(headers, span_context, config(opts, @otp_app))
       end
 

--- a/lib/tracer.ex
+++ b/lib/tracer.ex
@@ -251,8 +251,14 @@ defmodule Spandex.Tracer do
 
       @impl Spandex.Tracer
       def inject_context(headers, opts \\ []) do
-        span_context = current_context(opts)
-        Spandex.inject_context(headers, span_context, config(opts, @otp_app))
+        opts
+        |> current_context()
+        |> case do
+          {:ok, span_context} ->
+            Spandex.inject_context(headers, span_context, config(opts, @otp_app))
+
+          _ -> headers
+        end
       end
 
       defp merge_config(opts, otp_app) do

--- a/test/support/adapter.ex
+++ b/test/support/adapter.ex
@@ -42,6 +42,21 @@ defmodule Spandex.TestAdapter do
     end
   end
 
+  @doc """
+  Injects test HTTP headers to represent the specified SpanContext
+  """
+  @impl Spandex.Adapter
+  @spec inject_context(Spandex.headers(), SpanContext.t(), Tracer.opts()) :: Spandex.headers()
+  def inject_context(headers, %SpanContext{trace_id: trace_id, parent_id: parent_id, priority: priority}, _opts) do
+    [
+      {"x-test-trace-id", to_string(trace_id)},
+      {"x-test-parent-id", to_string(parent_id)},
+      {"x-test-sampling-priority", to_string(priority)}
+    ] ++ headers
+  end
+
+  # Private Helpers
+
   @spec get_first_header(conn :: Plug.Conn.t(), header_name :: binary) :: binary | nil
   defp get_first_header(conn, header_name) do
     conn


### PR DESCRIPTION
Adds APIs for `current_context` (to allow people to get access to a `SpanContext` based on the current span context) and `inject_context` to simplify adding distributed tracing headers to HTTP calls.

This somewhat-unfortunately also required an update to the `Adapter` behaviour, so I've also got a PR to `SpandexDatadog` queued up (https://github.com/spandex-project/spandex_datadog/pull/6).