### PR TITLE
document the options for the end trace plug

### DIFF
--- a/lib/plug/end_trace.ex
+++ b/lib/plug/end_trace.ex
@@ -21,6 +21,11 @@ defmodule Spandex.Plug.EndTrace do
                ]
              )
 
+  @doc """
+  Accepts and validates opts for the plug, and underlying tracer.
+
+  #{Optimal.Doc.document(@init_opts)}
+  """
   @spec init(opts :: Keyword.t()) :: Keyword.t()
   def init(opts) do
     Optimal.validate!(opts, @init_opts)


### PR DESCRIPTION
I got pretty confused when I kept getting a compile error telling me `tracer` was required, but I couldn't decipher it until I looked at the code for `EndTrace`. Since we have optimal and the schema here, lets add the free docs. 

/cc @zachdaniel @GregMefford @thebritican