### PR TITLE
!fix: Only inherit sensible attribute from parents

### DIFF
--- a/lib/span.ex
+++ b/lib/span.ex
@@ -153,6 +153,8 @@ defmodule Spandex.Span do
           right = struct_to_keyword(v2)
 
           merge_non_nils(left, right)
+        :private ->
+          raise ArgumentError, ":private is no longer a suppported key for Spandex spans. Use `tags` instead."
 
         :tags ->
           Keyword.merge(v1 || [], v2 || [])

--- a/lib/span.ex
+++ b/lib/span.ex
@@ -163,15 +163,6 @@ defmodule Spandex.Span do
     end)
   end
 
-  @spec merge_or_choose(Keyword.t() | nil, Keyword.t() | nil) :: Keyword.t() | nil
-  defp merge_or_choose(left, right) do
-    if left && right do
-      merge_retaining_nested(left, right)
-    else
-      left || right
-    end
-  end
-
   @spec merge_non_nils(Keyword.t(), Keyword.t()) :: Keyword.t()
   defp merge_non_nils(left, right) do
     Keyword.merge(left, right, fn _k, v1, v2 ->

--- a/test/span_test.exs
+++ b/test/span_test.exs
@@ -15,6 +15,19 @@ defmodule Spandex.Test.SpanTest do
     assert(span.service == :special_service)
   end
 
+  test "child spans do not inherit metadata" do
+    Tracer.trace "trace_name", service: :special_service do
+      Tracer.update_span(sql_query: [query: "SELECT ..", db: "some_db", rows: "42"])
+      Tracer.span("inner_span") do
+        :ok
+      end
+    end
+
+    span = Util.find_span("inner_span")
+
+    assert(span.http == nil)
+  end
+
   test "finishing a span does not override the completion time" do
     completion_time = :os.system_time(:nano_seconds)
     Tracer.start_trace("my_trace")

--- a/test/span_test.exs
+++ b/test/span_test.exs
@@ -41,7 +41,7 @@ defmodule Spandex.Test.SpanTest do
       assert(span.sql_query) == [query: "SELECT ..", db: "some_db", rows: "42"]
     end
 
-    test "tags are merged as well" do
+    test "tags are merged together" do
       Tracer.trace "trace_name" do
         Tracer.update_span(tags: [foo: :bar])
         Tracer.update_span(tags: [bar: :baz])


### PR DESCRIPTION
If you are using the `private` key for tags, you will need to
switch to using `tags`, or the appropriate top level tag attribute
like `sql_query` or `http`.

This is also 1 considered a breaking change because it is
likely/possible that implementations were relying on this
behavior. If you aren't leveraging tags, or if your
spans aren't very deep in general than you most likely
don't need to deal with this.