### PR TITLE
fix: update span on finish trace/update

### DIFF
--- a/lib/tracer.ex
+++ b/lib/tracer.ex
@@ -186,14 +186,14 @@ defmodule Spandex.Tracer do
       @impl Spandex.Tracer
       def finish_trace(opts \\ []) do
         opts
-        |> config(@otp_app)
+        |> validate_update_config(@otp_app)
         |> Spandex.finish_trace()
       end
 
       @impl Spandex.Tracer
       def finish_span(opts \\ []) do
         opts
-        |> config(@otp_app)
+        |> validate_update_config(@otp_app)
         |> Spandex.finish_span()
       end
 
@@ -257,7 +257,8 @@ defmodule Spandex.Tracer do
           {:ok, span_context} ->
             Spandex.inject_context(headers, span_context, config(opts, @otp_app))
 
-          _ -> headers
+          _ ->
+            headers
         end
       end
 
@@ -295,6 +296,7 @@ defmodule Spandex.Tracer do
           |> Optimal.validate!(schema)
           |> Keyword.put(:trace_key, __MODULE__)
           |> Keyword.put(:strategy, env[:strategy] || Spandex.Strategy.Pdict)
+          |> Keyword.put(:adapter, env[:adapter])
         end
       end
     end

--- a/test/span_test.exs
+++ b/test/span_test.exs
@@ -34,4 +34,26 @@ defmodule Spandex.Test.SpanTest do
 
     assert(span.completion_time != nil)
   end
+
+  test "spans are updated with the opts passed into `finish_trace`" do
+    Tracer.start_trace("my_trace")
+    Tracer.update_span(service: :my_app, type: :web)
+    Tracer.finish_trace(service: :your_app, type: :db)
+
+    span = Util.find_span("my_trace")
+
+    assert(span.service == :your_app)
+    assert(span.type == :db)
+  end
+
+  test "spans are updated with the opts passed into `finish_span`" do
+    Tracer.start_trace("my_trace")
+    Tracer.start_span("my_span")
+    Tracer.finish_span(service: :your_app)
+    Tracer.finish_trace()
+
+    span = Util.find_span("my_span")
+
+    assert(span.service == :your_app)
+  end
 end


### PR DESCRIPTION
We need to update the span according to any opts passed to `finish_span` and `finish_trace`.