### PR TITLE
Fix Tracer.opts/0 type

### DIFF
--- a/lib/tracer.ex
+++ b/lib/tracer.ex
@@ -107,7 +107,7 @@ defmodule Spandex.Tracer do
       Use to create and configure a tracer.
       """
       @impl Spandex.Tracer
-      @spec configure(Tracer.opts()) :: :ok
+      @spec configure(Spandex.Tracer.opts()) :: :ok
       def configure(opts) do
         case config(opts, @otp_app) do
           :disabled ->


### PR DESCRIPTION
## Problem
Dialyzer complains about a type not being found when using

```elixir
  use Spandex.Tracer, otp_app: :pg_payments
```
```
:0:unknown_type
Unknown type: Tracer.opts/0.
```

## Solution 
Fix the type