### PR TITLE
Update Ebert readme badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Inline docs](http://inch-ci.org/github/spandex-project/spandex.svg)](http://inch-ci.org/github/spandex-project/spandex)
 [![Coverage Status](https://coveralls.io/repos/github/spandex-project/spandex/badge.svg)](https://coveralls.io/github/spandex-project/spandex)
 [![Hex pm](http://img.shields.io/hexpm/v/spandex.svg?style=flat)](https://hex.pm/packages/spandex)
-[![Ebert](https://ebertapp.io/github/spandex-project/spandex.svg)](https://ebertapp.io/github/spandex-project/spandex)
+[![SourceLevel](https://sourcelevel.io/github/spandex-project/spandex.svg)](https://sourcelevel.io/github/spandex-project/spandex)
 
 View the [documentation](https://hexdocs.pm/spandex)
 


### PR DESCRIPTION
Ebert has been [renamed to SourceLevel](https://sourcelevel.io/blog/ebert-is-now-sourcelevel), and the badge is broken.

This pr updates the readme to point it to the new domain.