### PR TITLE
Add missing trace_id to logger metadata

### DIFF
--- a/lib/spandex.ex
+++ b/lib/spandex.ex
@@ -482,7 +482,7 @@ defmodule Spandex do
 
     with {:ok, span} <- Span.child_of(current_span, name, adapter.span_id(), adapter.now(), opts),
          {:ok, _trace} <- strategy.put_trace(opts[:trace_key], %{trace | stack: [span | trace.stack]}) do
-      Logger.metadata(span_id: span.id)
+      Logger.metadata(span_id: span.id, trace_id: trace.id)
       {:ok, span}
     end
   end
@@ -494,7 +494,7 @@ defmodule Spandex do
 
     with {:ok, span} <- span(name, opts, span_context, adapter),
          {:ok, _trace} <- strategy.put_trace(opts[:trace_key], %{trace | stack: [span]}) do
-      Logger.metadata(span_id: span.id)
+      Logger.metadata(span_id: span.id, trace_id: trace_id)
       {:ok, span}
     end
   end

--- a/lib/tracer.ex
+++ b/lib/tracer.ex
@@ -125,8 +125,6 @@ defmodule Spandex.Tracer do
 
           name = unquote(name)
           unquote(__MODULE__).start_trace(name, opts)
-          span_id = unquote(__MODULE__).current_span_id()
-          Logger.metadata(span_id: span_id)
 
           try do
             unquote(body)
@@ -147,8 +145,6 @@ defmodule Spandex.Tracer do
           opts = unquote(opts)
           name = unquote(name)
           unquote(__MODULE__).start_span(name, opts)
-          span_id = unquote(__MODULE__).current_span_id()
-          Logger.metadata(span_id: span_id)
 
           try do
             unquote(body)

--- a/test/decorators_test.exs
+++ b/test/decorators_test.exs
@@ -1,5 +1,7 @@
 defmodule Spandex.DecoratorsTest do
   use ExUnit.Case, async: true
+  import ExUnit.CaptureLog
+  require Logger
 
   alias Spandex.Test.Support.Decorated
   alias Spandex.Test.Support.OtherTracer
@@ -40,5 +42,30 @@ defmodule Spandex.DecoratorsTest do
     OtherTracer.finish_trace()
 
     assert Util.find_span("Spandex.Test.Support.Decorated.test_other_tracer/0") != nil
+  end
+
+  test "when decorating with trace, it logs span_id and trace_id" do
+    log =
+      capture_log(fn ->
+        Decorated.test_trace()
+        Logger.info("test logs")
+      end)
+
+    assert String.contains?(log, "trace_id")
+    assert String.contains?(log, "span_id")
+  end
+
+  test "when decorating with span, it logs span_id and trace_id" do
+    log =
+      capture_log(fn ->
+        Tracer.start_trace("my_trace")
+        Decorated.test_span()
+        Tracer.finish_trace()
+
+        Logger.info("test logs")
+      end)
+
+    assert String.contains?(log, "trace_id")
+    assert String.contains?(log, "span_id")
   end
 end

--- a/test/spandex_test.exs
+++ b/test/spandex_test.exs
@@ -1,6 +1,7 @@
 defmodule Spandex.Test.SpandexTest do
   use ExUnit.Case, async: true
   import ExUnit.CaptureLog
+  require Logger
 
   alias Spandex.Test.Util
 
@@ -57,6 +58,19 @@ defmodule Spandex.Test.SpandexTest do
       assert {:error, validation_errors} = Spandex.start_trace("root_span", @base_opts)
       assert {:service, "is required"} in validation_errors
     end
+
+    test "adds span_id, trace_id to log metadata" do
+      opts = @base_opts ++ @span_opts
+
+      log =
+        capture_log(fn ->
+          Spandex.start_trace("root_span", opts)
+          Logger.info("test logs")
+        end)
+
+      assert String.contains?(log, "trace_id")
+      assert String.contains?(log, "span_id")
+    end
   end
 
   describe "Spandex.start_span/2" do
@@ -91,6 +105,20 @@ defmodule Spandex.Test.SpandexTest do
       assert {:error, validation_errors} = Spandex.start_span("span_name", @base_opts ++ [type: "not an atom"])
 
       assert {:type, "must be of type :atom"} in validation_errors
+    end
+
+    test "adds span_id, trace_id to log metadata" do
+      opts = @base_opts ++ @span_opts
+
+      log =
+        capture_log(fn ->
+          Spandex.start_trace("root_span", opts)
+          Spandex.start_span("span_name", @base_opts)
+          Logger.info("test logs")
+        end)
+
+      assert String.contains?(log, "trace_id")
+      assert String.contains?(log, "span_id")
     end
   end
 


### PR DESCRIPTION
Does it make sense to log the `trace_id` in these cases as well? Thanks.