### PR TITLE
Update logger metadata when continue trace is called

### DIFF
--- a/lib/spandex.ex
+++ b/lib/spandex.ex
@@ -454,6 +454,8 @@ defmodule Spandex do
     adapter = opts[:adapter]
 
     with {:ok, top_span} <- span(name, opts, span_context, adapter) do
+      Logger.metadata(trace_id: span_context.trace_id, span_id: top_span.id)
+
       trace = %Trace{
         id: span_context.trace_id,
         priority: span_context.priority,

--- a/test/spandex_test.exs
+++ b/test/spandex_test.exs
@@ -448,6 +448,7 @@ defmodule Spandex.Test.SpandexTest do
                  @fake_stacktrace,
                  @base_opts ++ [type: "not an atom"]
                )
+
       assert {:type, "must be of type :atom"} in validation_errors
     end
   end
@@ -573,6 +574,20 @@ defmodule Spandex.Test.SpandexTest do
 
       assert {:type, "must be of type :atom"} in validation_errors
     end
+
+    test "adds span_id, trace_id to log metadata" do
+      opts = @base_opts ++ @span_opts
+      span_context = %SpanContext{trace_id: 123, parent_id: 456}
+
+      log =
+        capture_log(fn ->
+          Spandex.continue_trace("root_span", span_context, opts)
+          Logger.info("test logs")
+        end)
+
+      assert String.contains?(log, "trace_id")
+      assert String.contains?(log, "span_id")
+    end
   end
 
   describe "Spandex.continue_trace/4 (DEPRECATED)" do
@@ -603,6 +618,19 @@ defmodule Spandex.Test.SpandexTest do
                Spandex.continue_trace("span_name", 123, 456, @base_opts ++ [type: "not an atom"])
 
       assert {:type, "must be of type :atom"} in validation_errors
+    end
+
+    test "adds span_id, trace_id to log metadata" do
+      opts = @base_opts ++ @span_opts
+
+      log =
+        capture_log(fn ->
+          Spandex.continue_trace("root_span", 123, 456, opts)
+          Logger.info("test logs")
+        end)
+
+      assert String.contains?(log, "trace_id")
+      assert String.contains?(log, "span_id")
     end
   end
 


### PR DESCRIPTION
Since this entry point can be called when a distributed trace is received from
another service, calling Logger.metadata in the same way it is called in
`start_trace/2` seems to cover that use-case (it should be idempotent, thus safe
if the same trace_id is already there from another local process).

However, I believe this may also fix an issue as a new span is created when
continuing a trace, which that should be updated in logs from this moment on.

Do you think this may be helpful?