### PR TITLE
feat!: allow headers to be passed into `Spandex.distributed_context/2`

### DIFF
--- a/lib/adapter.ex
+++ b/lib/adapter.ex
@@ -6,6 +6,9 @@ defmodule Spandex.Adapter do
   @callback distributed_context(Plug.Conn.t(), Keyword.t()) ::
               {:ok, Spandex.SpanContext.t()}
               | {:error, atom()}
+  @callback distributed_context(Spandex.headers(), Keyword.t()) ::
+              {:ok, Spandex.SpanContext.t()}
+              | {:error, atom()}
   @callback inject_context(Spandex.headers(), Spandex.SpanContext.t(), Keyword.t()) :: Spandex.headers()
   @callback trace_id() :: Spandex.id()
   @callback span_id() :: Spandex.id()

--- a/lib/spandex.ex
+++ b/lib/spandex.ex
@@ -403,14 +403,13 @@ defmodule Spandex do
   @doc """
   Returns the context from a given set of HTTP headers, as determined by the adapter.
   """
-  @spec distributed_context(Plug.Conn.t(), Tracer.opts()) ::
-          {:ok, SpanContext.t()}
-          | {:error, :disabled}
+  @spec distributed_context(Plug.Conn.t(), Tracer.opts()) :: {:ok, SpanContext.t()} | {:error, :disabled}
+  @spec distributed_context(headers(), Tracer.opts()) :: {:ok, SpanContext.t()} | {:error, :disabled}
   def distributed_context(_, :disabled), do: {:error, :disabled}
 
-  def distributed_context(conn, opts) do
+  def distributed_context(metadata, opts) do
     adapter = opts[:adapter]
-    adapter.distributed_context(conn, opts)
+    adapter.distributed_context(metadata, opts)
   end
 
   @doc """

--- a/test/spandex_test.exs
+++ b/test/spandex_test.exs
@@ -678,7 +678,7 @@ defmodule Spandex.Test.SpandexTest do
     end
   end
 
-  describe "Spandex.distributed_context/2" do
+  describe "Spandex.distributed_context/2 with Plug.Conn" do
     test "returns a distributed context representation" do
       conn =
         :get
@@ -699,6 +699,28 @@ defmodule Spandex.Test.SpandexTest do
     test "returns an error if tracing is disabled" do
       conn = Plug.Test.conn(:get, "/")
       assert {:error, :disabled} == Spandex.distributed_context(conn, :disabled)
+    end
+  end
+
+  describe "Spandex.distributed_context/2 with headers()" do
+    test "returns a distributed context representation" do
+      list_headers = [
+        {"x-test-trace-id", 1234},
+        {"x-test-parent-id", 5678},
+        {"x-test-sampling-priority", 10}
+      ]
+
+      assert {:ok, %SpanContext{} = span_context} = Spandex.distributed_context(list_headers, @base_opts)
+      assert %SpanContext{trace_id: 1234, parent_id: 5678, priority: 10} = span_context
+
+      map_headers = %{
+        "x-test-trace-id" => 1234,
+        "x-test-parent-id" => 5678,
+        "x-test-sampling-priority" => 10
+      }
+
+      assert {:ok, %SpanContext{} = span_context} = Spandex.distributed_context(map_headers, @base_opts)
+      assert %SpanContext{trace_id: 1234, parent_id: 5678, priority: 10} = span_context
     end
   end
 


### PR DESCRIPTION
This change allows headers to be specified in `Spandex.distributed_context/2` as an alternative to `Plug.Conn`. This is more compatible with the current signature of `Spandex.inject_context/3` and allows Spandex to be used to extract trace information from connections that may not be relying on Plug e.g. GRPC.

Fixes #112

Haven't been using Elixir for too long, so let me know if there is anything funky going on that I should be doing differently.

PR for spandex_datadog will follow once this one gets sorted out.