### PR TITLE
Correctly configure sender in tracer

### DIFF
--- a/lib/tracer.ex
+++ b/lib/tracer.ex
@@ -293,6 +293,7 @@ defmodule Spandex.Tracer do
           |> Keyword.put(:trace_key, __MODULE__)
           |> Keyword.put(:strategy, env[:strategy] || Spandex.Strategy.Pdict)
           |> Keyword.put(:adapter, env[:adapter])
+          |> Keyword.put(:sender, env[:sender])
         end
       end
     end


### PR DESCRIPTION
As of 43c256b6926a065345ed38115ca1ba6ca0998583 the sender was no longer correctly being configured for the tracer. This causes the tests in spandex_datadog to fail as the default adapter will always be used.

This change re-adds the ability to configure the sender on the tracer.