### PR TITLE
fix: add a name to failed traces

### DIFF
--- a/lib/spandex.ex
+++ b/lib/spandex.ex
@@ -37,7 +37,7 @@ defmodule Spandex do
     strategy = opts[:strategy]
 
     if strategy.trace_active?(opts[:trace_key]) do
-      Logger.error("Tried to start a trace over top of another trace.")
+      Logger.error("Tried to start a trace over top of another trace: #{name}.")
       {:error, :trace_running}
     else
       do_start_trace(name, opts)
@@ -351,7 +351,7 @@ defmodule Spandex do
     strategy = opts[:strategy]
 
     if strategy.trace_active?(opts[:trace_key]) do
-      Logger.error("Tried to continue a trace over top of another trace.")
+      Logger.error("Tried to continue a trace over top of another trace: #{name}.")
       {:error, :trace_already_present}
     else
       do_continue_trace(name, span_context, opts)
@@ -393,7 +393,7 @@ defmodule Spandex do
     strategy = opts[:strategy]
 
     if strategy.trace_active?(opts[:trace_key]) do
-      Logger.error("Tried to continue a trace over top of another trace.")
+      Logger.error("Tried to continue a trace over top of another trace: #{name}.")
       {:error, :trace_already_present}
     else
       do_continue_trace_from_span(name, span, opts)


### PR DESCRIPTION
When errors like `Tried to start a trace over top of another trace` happen, it's not obvious from where they originate. So I added a name to log messages