### PR TITLE
Replace System.stacktrace with __STACKTRACE__

### DIFF
--- a/lib/span.ex
+++ b/lib/span.ex
@@ -112,7 +112,7 @@ defmodule Spandex.Span do
     ],
     error: [
       exception: ArgumentError.exception("foo"),
-      stacktrace: System.stacktrace(),
+      stacktrace: __STACKTRACE__,
       error?: true # Used for specifying that a span is an error when there is no exception or stacktrace.
     ],
     sql_query: [

--- a/lib/tracer.ex
+++ b/lib/tracer.ex
@@ -130,7 +130,7 @@ defmodule Spandex.Tracer do
             unquote(body)
           rescue
             exception ->
-              stacktrace = System.stacktrace()
+              stacktrace = __STACKTRACE__
               _ = unquote(__MODULE__).span_error(exception, stacktrace, opts)
               reraise exception, stacktrace
           after
@@ -150,7 +150,7 @@ defmodule Spandex.Tracer do
             unquote(body)
           rescue
             exception ->
-              stacktrace = System.stacktrace()
+              stacktrace = __STACKTRACE__
               _ = unquote(__MODULE__).span_error(exception, stacktrace, opts)
               reraise exception, stacktrace
           after

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Spandex.Mixfile do
     [
       app: :spandex,
       version: @version,
-      elixir: "~> 1.3",
+      elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Elixir 1.11 generates deprecation warnings from the use of `System.stacktrace/0` in the `trace` macro.

Eg:
```
warning: System.stacktrace/0 is deprecated, use __STACKTRACE__ instead
  lib/services/search/elasticsearch.ex:195
```

Since the warning is reported as being in my application code (rather than the library), the build fails when compiling with the `--warnings-as-errors` flag.

This PR changes the implementation to use `__STACKTRACE__` instead, which should be equivalent.
I've also updated the minimum elixir version to [1.7](https://github.com/elixir-lang/elixir/releases/tag/v1.7.0), since `__STACKTRACE__` isn't supported in lower versions.