### PR TITLE
Run mix format in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
       - checkout
 
       # specify any bash command here prefixed with `run: `
+      - run: mix format --check-formatted
       - run: mix local.hex --force
       - run: mix local.rebar --force
       - run: mix deps.get

--- a/mix.exs
+++ b/mix.exs
@@ -66,7 +66,6 @@ defmodule Spandex.Mixfile do
       {:makeup, "~> 1.0.1", only: :dev},
       {:makeup_elixir, "~> 0.14.0", only: :dev},
       {:nimble_parsec, "~> 0.5.3", only: :dev},
-
       {:decorator, "~> 1.2", optional: true},
       {:optimal, "~> 0.3.3"},
       {:plug, ">= 1.0.0"}


### PR DESCRIPTION
There's an inconsistency in formatting of `mix.exs` - it got there because 1) we're not running `mix format --check-formatted` in CI, 2) we're not allowing CI checks to run on forks. This PR is fixing the former (and the formatting error itself). Could anyone help with the latter? To allow builds on PRs from forks you need to enable "Build forked pull requests" under the Advanced tab in project settings in CircleCI.