### PR TITLE
Set up sponsorship links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: [zachdaniel, gregmefford]

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
 # These are supported funding model platforms
 
-github: [zachdaniel, gregmefford]
+github: [gregmefford]


### PR DESCRIPTION
I set up a GitHub sponsorship profile the other day and I saw that you also have one @zachdaniel, so I figure it doesn't hurt to make that easier for people to find. I believe this will cause our sponsorship details to be included in `mix hex.sponsor` output because we have a `github` link in our `mix.exs`, but we'll see if that's really how it works.