### PR TITLE
Remove is_binary guard from macros

### DIFF
--- a/lib/tracer.ex
+++ b/lib/tracer.ex
@@ -119,7 +119,7 @@ defmodule Spandex.Tracer do
       end
 
       @impl Spandex.Tracer
-      defmacro trace(name, opts \\ [], do: body) when is_binary(name) do
+      defmacro trace(name, opts \\ [], do: body) do
         quote do
           opts = unquote(opts)
 
@@ -140,7 +140,7 @@ defmodule Spandex.Tracer do
       end
 
       @impl Spandex.Tracer
-      defmacro span(name, opts \\ [], do: body) when is_binary(name) do
+      defmacro span(name, opts \\ [], do: body) do
         quote do
           opts = unquote(opts)
           name = unquote(name)


### PR DESCRIPTION
The `is_binary` guards on `trace/2` and `span/2` macros cause problems when the span name is computed at runtime. 
If the span name is a variable or an interpolated string like "name.#{key}", then the guard fails, as the macro receives an AST structure instead of a string. This PR removes the guard. 

To get the similar effect of protecting against incorrect usage, the guard could be added to `Spandex.start_trace/2`.